### PR TITLE
feat: SignalR hub for real-time attendance (Closes #10 backend)

### DIFF
--- a/src/LanManager.Api/Controllers/CheckInController.cs
+++ b/src/LanManager.Api/Controllers/CheckInController.cs
@@ -1,15 +1,20 @@
 using LanManager.Api.DTOs;
+using LanManager.Api.Hubs;
 using LanManager.Data;
 using LanManager.Data.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 namespace LanManager.Api.Controllers;
 
 [ApiController]
 [Route("api/events/{eventId:guid}")]
-public class CheckInController(LanManagerDbContext db, UserManager<ApplicationUser> userManager) : ControllerBase
+public class CheckInController(
+    LanManagerDbContext db,
+    UserManager<ApplicationUser> userManager,
+    IHubContext<AttendanceHub> hubContext) : ControllerBase
 {
     [HttpPost("checkin")]
     public async Task<ActionResult<CheckInDto>> CheckIn(Guid eventId, [FromBody] CheckInRequest request)
@@ -40,6 +45,9 @@ public class CheckInController(LanManagerDbContext db, UserManager<ApplicationUs
         db.CheckInRecords.Add(record);
         await db.SaveChangesAsync();
 
+        await hubContext.Clients.All.SendAsync("UserCheckedIn",
+            new AttendanceBroadcast(eventId, record.UserId, user.UserName ?? "", record.CheckedInAt));
+
         return CreatedAtAction(nameof(GetAttendance), new { eventId },
             ToDto(record, user.UserName ?? string.Empty));
     }
@@ -56,6 +64,9 @@ public class CheckInController(LanManagerDbContext db, UserManager<ApplicationUs
 
         record.CheckedOutAt = DateTime.UtcNow;
         await db.SaveChangesAsync();
+
+        await hubContext.Clients.All.SendAsync("UserCheckedOut",
+            new CheckOutBroadcast(eventId, record.UserId, record.User.UserName ?? "", record.CheckedOutAt!.Value));
 
         return Ok(ToDto(record, record.User.UserName ?? string.Empty));
     }

--- a/src/LanManager.Api/Hubs/AttendanceBroadcast.cs
+++ b/src/LanManager.Api/Hubs/AttendanceBroadcast.cs
@@ -1,0 +1,4 @@
+namespace LanManager.Api.Hubs;
+
+public record AttendanceBroadcast(Guid EventId, Guid UserId, string UserName, DateTime CheckedInAt);
+public record CheckOutBroadcast(Guid EventId, Guid UserId, string UserName, DateTime CheckedOutAt);

--- a/src/LanManager.Api/Hubs/AttendanceHub.cs
+++ b/src/LanManager.Api/Hubs/AttendanceHub.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace LanManager.Api.Hubs;
+
+public class AttendanceHub : Hub
+{
+    // Clients connect to this hub and receive broadcasts.
+    // No client-to-server methods needed for now.
+}

--- a/src/LanManager.Api/Program.cs
+++ b/src/LanManager.Api/Program.cs
@@ -1,3 +1,4 @@
+using LanManager.Api.Hubs;
 using LanManager.Data;
 using LanManager.Data.Models;
 using Microsoft.AspNetCore.Identity;
@@ -6,7 +7,17 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+builder.Services.AddSignalR();
 builder.Services.AddOpenApi();
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.WithOrigins("http://localhost:5173")
+              .AllowAnyHeader()
+              .AllowAnyMethod()
+              .AllowCredentials());
+});
 
 builder.Services.AddDbContext<LanManagerDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
@@ -23,7 +34,9 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseCors();
 app.UseAuthorization();
 app.MapControllers();
+app.MapHub<AttendanceHub>("/hubs/attendance");
 
 app.Run();


### PR DESCRIPTION
## Summary

Implements the backend SignalR infrastructure for real-time attendance broadcasting (part 1 of #10).

### Changes
- **Program.cs**: Registers AddSignalR(), AddCors() (allowing Vite dev server at http://localhost:5173 with credentials), maps AttendanceHub at /hubs/attendance, inserts UseCors() before UseAuthorization()
- **Hubs/AttendanceHub.cs**: Empty hub — clients connect and receive server broadcasts
- **Hubs/AttendanceBroadcast.cs**: Two broadcast records:
  - \AttendanceBroadcast(EventId, UserId, UserName, CheckedInAt)\
  - \CheckOutBroadcast(EventId, UserId, UserName, CheckedOutAt)\
- **CheckInController.cs**: Injects \IHubContext<AttendanceHub>\, broadcasts \UserCheckedIn\ after check-in and \UserCheckedOut\ after checkout

### SignalR event names
| Event | Trigger |
|---|---|
| \UserCheckedIn\ | POST /api/events/{id}/checkin succeeds |
| \UserCheckedOut\ | POST /api/events/{id}/checkout succeeds |

### Build
\dotnet build\ passes with no warnings or errors.

> **Merge order:** This PR must be merged before the frontend PR (squad/10-signalr-frontend).