### PR TITLE
feat: MAUI door scanner with QR camera (Closes #28)

### DIFF
--- a/src/LanManager.Maui/AppShell.xaml.cs
+++ b/src/LanManager.Maui/AppShell.xaml.cs
@@ -1,9 +1,12 @@
-﻿namespace LanManager.Maui;
+﻿using LanManager.Maui.Views;
+
+namespace LanManager.Maui;
 
 public partial class AppShell : Shell
 {
 	public AppShell()
 	{
 		InitializeComponent();
+		Routing.RegisterRoute("DoorScanPage", typeof(DoorScanPage));
 	}
 }

--- a/src/LanManager.Maui/LanManager.Maui.csproj
+++ b/src/LanManager.Maui/LanManager.Maui.csproj
@@ -69,6 +69,8 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
+		<PackageReference Include="ZXing.Net.MAUI" Version="0.*" />
+		<PackageReference Include="ZXing.Net.MAUI.Controls" Version="0.*" />
 	</ItemGroup>
 
 </Project>

--- a/src/LanManager.Maui/MauiProgram.cs
+++ b/src/LanManager.Maui/MauiProgram.cs
@@ -2,6 +2,7 @@
 using LanManager.Maui.Services;
 using LanManager.Maui.ViewModels;
 using LanManager.Maui.Views;
+using ZXing.Net.Maui.Controls;
 
 namespace LanManager.Maui;
 
@@ -12,6 +13,7 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<App>()
+			.UseBarcodeReader()
 			.ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -30,11 +32,13 @@ public static class MauiProgram
 		builder.Services.AddTransient<MainViewModel>();
 		builder.Services.AddTransient<CheckInViewModel>();
 		builder.Services.AddTransient<AttendanceViewModel>();
+		builder.Services.AddTransient<DoorScanViewModel>();
 
 		// Register Views
 		builder.Services.AddTransient<MainPage>();
 		builder.Services.AddTransient<CheckInPage>();
 		builder.Services.AddTransient<AttendancePage>();
+		builder.Services.AddTransient<DoorScanPage>();
 
 		return builder.Build();
 	}

--- a/src/LanManager.Maui/Services/ApiService.cs
+++ b/src/LanManager.Maui/Services/ApiService.cs
@@ -105,6 +105,24 @@ public class ApiService
             return new List<AttendanceDto>();
         }
     }
+
+    public async Task<DoorPassDto?> DoorScanAsync(Guid eventId, Guid userId, string direction)
+    {
+        var request = new DoorScanRequest(userId, direction);
+        var response = await _httpClient.PostAsJsonAsync($"/api/events/{eventId}/door-scan", request);
+        if (response.IsSuccessStatusCode)
+            return await response.Content.ReadFromJsonAsync<DoorPassDto>(_jsonOptions);
+        var error = await response.Content.ReadAsStringAsync();
+        throw new HttpRequestException($"Door scan failed ({response.StatusCode}): {error}");
+    }
+
+    public async Task<int> GetOutsideCountAsync(Guid eventId)
+    {
+        try {
+            var outside = await _httpClient.GetFromJsonAsync<List<OutsideUserDto>>($"/api/events/{eventId}/outside", _jsonOptions);
+            return outside?.Count ?? 0;
+        } catch { return 0; }
+    }
 }
 
 public record CheckInRequest(Guid UserId);
@@ -113,3 +131,6 @@ public record AttendanceDto(Guid UserId, string UserName, DateTime CheckedInAt);
 public record UserDto(Guid Id, string Name, string UserName, string Email);
 public record EventDto(Guid Id, string Name, string? Description, string? Location, DateTime StartDate, DateTime EndDate, int Capacity, string Status, DateTime CreatedAt);
 public record PagedResult<T>(IEnumerable<T> Items, int Page, int PageSize, int TotalCount);
+public record DoorScanRequest(Guid UserId, string Direction);
+public record DoorPassDto(Guid Id, Guid EventId, Guid UserId, string UserName, string Direction, DateTime ScannedAt);
+public record OutsideUserDto(Guid UserId, string UserName, DateTime ExitedAt);

--- a/src/LanManager.Maui/ViewModels/CheckInViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/CheckInViewModel.cs
@@ -140,6 +140,12 @@ public partial class CheckInViewModel : ObservableObject, IQueryAttributable
     }
 
     [RelayCommand]
+    private async Task GoToDoorScannerAsync()
+    {
+        await Shell.Current.GoToAsync($"DoorScanPage?eventId={_eventId}&eventName={Uri.EscapeDataString(EventName)}");
+    }
+
+    [RelayCommand]
     private void ToggleCheckOutMode()
     {
         IsCheckOutMode = !IsCheckOutMode;

--- a/src/LanManager.Maui/ViewModels/DoorScanViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/DoorScanViewModel.cs
@@ -1,0 +1,93 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LanManager.Maui.Services;
+
+namespace LanManager.Maui.ViewModels;
+
+public partial class DoorScanViewModel : ObservableObject, IQueryAttributable
+{
+    private readonly ApiService _apiService;
+    private Guid _eventId;
+    private DateTime _lastScanTime = DateTime.MinValue;
+    private const int ScanCooldownMs = 1000;
+
+    [ObservableProperty] private string _eventName = string.Empty;
+    [ObservableProperty] private bool _isExitMode = true; // true=Exit, false=Entry
+    [ObservableProperty] private string _directionLabel = "EXIT";
+    [ObservableProperty] private Color _directionColor = Colors.Red;
+    [ObservableProperty] private string _statusMessage = string.Empty;
+    [ObservableProperty] private Color _statusColor = Colors.Transparent;
+    [ObservableProperty] private int _outsideCount;
+    [ObservableProperty] private bool _isBusy;
+
+    public DoorScanViewModel(ApiService apiService) { _apiService = apiService; }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("eventId", out var id) && Guid.TryParse(id?.ToString(), out var guid))
+        {
+            _eventId = guid;
+            _ = RefreshOutsideCountAsync();
+        }
+        if (query.TryGetValue("eventName", out var name))
+            EventName = name?.ToString() ?? string.Empty;
+    }
+
+    [RelayCommand]
+    private void ToggleDirection()
+    {
+        IsExitMode = !IsExitMode;
+        DirectionLabel = IsExitMode ? "EXIT" : "ENTRY";
+        DirectionColor = IsExitMode ? Colors.Red : Colors.Green;
+    }
+
+    // Called when ZXing detects a barcode
+    public async Task OnBarcodeDetectedAsync(string barcodeValue)
+    {
+        // Cooldown check
+        if ((DateTime.Now - _lastScanTime).TotalMilliseconds < ScanCooldownMs) return;
+        _lastScanTime = DateTime.Now;
+
+        if (!Guid.TryParse(barcodeValue, out var userId)) return;
+        if (IsBusy) return;
+        IsBusy = true;
+
+        try
+        {
+            var direction = IsExitMode ? "Exit" : "Entry";
+            var result = await _apiService.DoorScanAsync(_eventId, userId, direction);
+            var emoji = IsExitMode ? "→" : "←";
+            ShowSuccess($"{emoji} {(IsExitMode ? "Outside" : "Back")}: {result?.UserName}");
+            _ = RefreshOutsideCountAsync();
+        }
+        catch (HttpRequestException ex)
+        {
+            if (ex.Message.Contains("400")) ShowError("Not checked in");
+            else if (ex.Message.Contains("404")) ShowError("User not found");
+            else ShowError("Scan failed");
+        }
+        finally { IsBusy = false; }
+    }
+
+    [RelayCommand]
+    private async Task RefreshOutsideCountAsync()
+    {
+        OutsideCount = await _apiService.GetOutsideCountAsync(_eventId);
+    }
+
+    [RelayCommand]
+    private async Task GoBackAsync() => await Shell.Current.GoToAsync("..");
+
+    private async void ShowSuccess(string msg)
+    {
+        StatusMessage = msg; StatusColor = Colors.Green;
+        await Task.Delay(2000);
+        StatusMessage = string.Empty; StatusColor = Colors.Transparent;
+    }
+    private async void ShowError(string msg)
+    {
+        StatusMessage = msg; StatusColor = Colors.Red;
+        await Task.Delay(3000);
+        StatusMessage = string.Empty; StatusColor = Colors.Transparent;
+    }
+}

--- a/src/LanManager.Maui/Views/CheckInPage.xaml
+++ b/src/LanManager.Maui/Views/CheckInPage.xaml
@@ -13,6 +13,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -80,8 +81,15 @@
                     Margin="5,0,0,0" />
         </Grid>
 
+        <!-- Door scanner button -->
+        <Button Grid.Row="4"
+                Text="📷 Door Scanner"
+                Command="{Binding GoToDoorScannerCommand}"
+                BackgroundColor="#e74c3c" TextColor="White"
+                CornerRadius="6" Margin="0,0,0,10" />
+
         <!-- User list -->
-        <CollectionView Grid.Row="4"
+        <CollectionView Grid.Row="5"
                        ItemsSource="{Binding FilteredUsers}"
                        SelectionMode="None">
             <CollectionView.ItemTemplate>
@@ -120,7 +128,7 @@
         </CollectionView>
 
         <!-- Loading overlay -->
-        <ActivityIndicator Grid.RowSpan="5"
+        <ActivityIndicator Grid.RowSpan="6"
                           IsRunning="{Binding IsLoading}"
                           IsVisible="{Binding IsLoading}"
                           Color="{StaticResource Primary}"

--- a/src/LanManager.Maui/Views/DoorScanPage.xaml
+++ b/src/LanManager.Maui/Views/DoorScanPage.xaml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:zxing="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI.Controls"
+             xmlns:vm="clr-namespace:LanManager.Maui.ViewModels"
+             x:Class="LanManager.Maui.Views.DoorScanPage"
+             x:DataType="vm:DoorScanViewModel"
+             Title="Door Scanner">
+
+    <Grid RowDefinitions="Auto,Auto,Auto,*,Auto">
+        <!-- Header -->
+        <Grid Grid.Row="0" Padding="12" ColumnDefinitions="*,Auto" BackgroundColor="#1a1a2e">
+            <Label Text="{Binding EventName}" TextColor="White" FontSize="16" VerticalOptions="Center"/>
+            <Button Grid.Column="1" Text="← Back" Command="{Binding GoBackCommand}"
+                    BackgroundColor="Transparent" TextColor="White"/>
+        </Grid>
+
+        <!-- Direction Toggle -->
+        <Button Grid.Row="1" Text="{Binding DirectionLabel}"
+                BackgroundColor="{Binding DirectionColor}"
+                TextColor="White" FontSize="24" FontAttributes="Bold"
+                HeightRequest="70" Command="{Binding ToggleDirectionCommand}"
+                Margin="0"/>
+
+        <!-- Outside Count -->
+        <Label Grid.Row="2" Text="{Binding OutsideCount, StringFormat='{0} outside'}"
+               HorizontalOptions="Center" Margin="8" FontSize="14" TextColor="Gray"/>
+
+        <!-- Camera -->
+        <zxing:CameraBarcodeReaderView Grid.Row="3"
+                          x:Name="cameraView"
+                          BarcodesDetected="OnBarcodesDetected"/>
+
+        <!-- Status Banner -->
+        <Border Grid.Row="4" BackgroundColor="{Binding StatusColor}"
+                IsVisible="{Binding StatusMessage, Converter={StaticResource StringNotEmptyConverter}}"
+                Padding="16" Margin="0">
+            <Label Text="{Binding StatusMessage}" TextColor="White"
+                   FontSize="18" FontAttributes="Bold" HorizontalOptions="Center"/>
+        </Border>
+    </Grid>
+</ContentPage>

--- a/src/LanManager.Maui/Views/DoorScanPage.xaml.cs
+++ b/src/LanManager.Maui/Views/DoorScanPage.xaml.cs
@@ -1,0 +1,23 @@
+using LanManager.Maui.ViewModels;
+using ZXing.Net.Maui;
+
+namespace LanManager.Maui.Views;
+
+public partial class DoorScanPage : ContentPage
+{
+    private DoorScanViewModel _viewModel => (DoorScanViewModel)BindingContext;
+
+    public DoorScanPage(DoorScanViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    private void OnBarcodesDetected(object sender, BarcodeDetectionEventArgs e)
+    {
+        var first = e.Results.FirstOrDefault();
+        if (first is null) return;
+        MainThread.BeginInvokeOnMainThread(async () =>
+            await _viewModel.OnBarcodeDetectedAsync(first.Value));
+    }
+}


### PR DESCRIPTION
## Summary

Implements a door scanner screen for MAUI app using ZXing.Net.MAUI for QR code scanning. Enables operators to track attendees exiting and re-entering the LAN party venue.

## Changes

### Dependencies
- **ZXing.Net.MAUI** v0.* — QR/barcode scanning
- **ZXing.Net.MAUI.Controls** v0.* — camera control
- Registered .UseBarcodeReader() in MauiProgram

### New Components
- **DoorScanViewModel** — manages scan state, direction toggle, outside count
  - Scan cooldown (1000ms) prevents double-scans
  - Exit/Entry mode toggle (red/green UI)
  - Success/error feedback with auto-dismiss
- **DoorScanPage** — full-screen camera view
  - Header: event name + back button
  - Toggle button: EXIT (red) / ENTRY (green)
  - Outside count badge
  - ZXing camera view
  - Status banner for feedback

### API Integration
Extended ApiService.cs:
- \DoorScanAsync(eventId, userId, direction)\ → \DoorPassDto\
- \GetOutsideCountAsync(eventId)\ → int count
- Added DTOs: \DoorScanRequest\, \DoorPassDto\, \OutsideUserDto\

### Navigation
- Registered \DoorScanPage\ route in \AppShell\
- Added \GoToDoorScannerCommand\ to \CheckInViewModel\
- Added **📷 Door Scanner** button to \CheckInPage\

## Operator Flow
1. From check-in screen, tap **📷 Door Scanner**
2. Toggle between **EXIT** and **ENTRY** mode as needed
3. Attendee shows QR code (userId GUID)
4. Scan code → instant feedback: \→ Outside: [Name]\ or \← Back: [Name]\
5. Outside count updates automatically

## Testing
- ✅ Builds successfully: \dotnet build src/LanManager.Maui/LanManager.Maui.csproj -f net10.0-windows10.0.19041.0\
- ⚠️  26 warnings (MVVMTK0045 AOT compatibility, CS8622 nullability) — non-blocking
- 📱 Designed for Windows tablet at door stations

## Related
- Depends on #27 (door-scan API endpoints) — **merged to master**
- Blocks #29 (door log UI) — this provides the scanning mechanism

Closes #28