### PR TITLE
feat: JWT authentication and role-based authorization (Closes #25)

### DIFF
--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -1,0 +1,17 @@
+import { getToken, clearToken } from './auth';
+
+export async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const token = getToken();
+  const headers = new Headers(options.headers);
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+  headers.set('Content-Type', 'application/json');
+
+  const res = await fetch(url, { ...options, headers });
+
+  if (res.status === 401) {
+    clearToken();
+    window.location.href = '/login';
+  }
+
+  return res;
+}

--- a/frontend/src/api/attendance.ts
+++ b/frontend/src/api/attendance.ts
@@ -1,4 +1,5 @@
-import { config } from '../config';
+﻿import { config } from '../config';
+import { apiFetch } from './apiClient';
 
 export interface AttendanceDto {
   userId: string;
@@ -9,7 +10,7 @@ export interface AttendanceDto {
 const BASE = `${config.apiUrl}/api/events`;
 
 export async function getAttendance(eventId: string): Promise<AttendanceDto[]> {
-  const res = await fetch(`${BASE}/${eventId}/attendance`);
+  const res = await apiFetch(`${BASE}/${eventId}/attendance`);
   if (!res.ok) throw new Error(`Failed to fetch attendance: ${res.statusText}`);
   return res.json();
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,44 @@
+import { config } from '../config';
+
+export interface LoginResponse {
+  token: string;
+  userId: string;
+  name: string;
+  email: string;
+  roles: string[];
+}
+
+export async function login(email: string, password: string): Promise<LoginResponse> {
+  const res = await fetch(`${config.apiUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ message: 'Login failed' }));
+    throw new Error(err.message ?? 'Login failed');
+  }
+  return res.json();
+}
+
+export function getToken(): string | null {
+  return localStorage.getItem('jwt_token');
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem('jwt_token', token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem('jwt_token');
+  localStorage.removeItem('jwt_user');
+}
+
+export function getUser(): LoginResponse | null {
+  const raw = localStorage.getItem('jwt_user');
+  return raw ? JSON.parse(raw) : null;
+}
+
+export function setUser(user: LoginResponse): void {
+  localStorage.setItem('jwt_user', JSON.stringify(user));
+}

--- a/frontend/src/api/doorpass.ts
+++ b/frontend/src/api/doorpass.ts
@@ -1,4 +1,5 @@
-import { config } from '../config';
+﻿import { config } from '../config';
+import { apiFetch } from './apiClient';
 
 export interface OutsideUserDto {
   userId: string;
@@ -18,13 +19,13 @@ export interface DoorPassDto {
 const BASE = `${config.apiUrl}/api/events`;
 
 export async function getOutside(eventId: string): Promise<OutsideUserDto[]> {
-  const res = await fetch(`${BASE}/${eventId}/outside`);
+  const res = await apiFetch(`${BASE}/${eventId}/outside`);
   if (!res.ok) throw new Error(`Failed to fetch outside users: ${res.statusText}`);
   return res.json();
 }
 
 export async function getDoorLog(eventId: string, page = 1, pageSize = 50): Promise<DoorPassDto[]> {
-  const res = await fetch(`${BASE}/${eventId}/door-log?page=${page}&pageSize=${pageSize}`);
+  const res = await apiFetch(`${BASE}/${eventId}/door-log?page=${page}&pageSize=${pageSize}`);
   if (!res.ok) throw new Error(`Failed to fetch door log: ${res.statusText}`);
   return res.json();
 }

--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -1,4 +1,5 @@
-import { config } from '../config';
+﻿import { config } from '../config';
+import { apiFetch } from './apiClient';
 import type { UserDto } from './users';
 
 export interface EventDto {
@@ -34,21 +35,20 @@ export async function getEvents(status?: EventStatus, sort?: string): Promise<Ev
   if (status && status !== 'All') params.set('status', status);
   if (sort) params.set('sort', sort);
   const query = params.toString();
-  const res = await fetch(query ? `${BASE}?${query}` : BASE);
+  const res = await apiFetch(query ? `${BASE}?${query}` : BASE);
   if (!res.ok) throw new Error(`Failed to fetch events: ${res.statusText}`);
   return res.json();
 }
 
 export async function getEvent(id: string): Promise<EventDto> {
-  const res = await fetch(`${BASE}/${id}`);
+  const res = await apiFetch(`${BASE}/${id}`);
   if (!res.ok) throw new Error(`Failed to fetch event: ${res.statusText}`);
   return res.json();
 }
 
 export async function createEvent(data: CreateEventRequest): Promise<EventDto> {
-  const res = await fetch(BASE, {
+  const res = await apiFetch(BASE, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
   if (!res.ok) {
@@ -59,9 +59,8 @@ export async function createEvent(data: CreateEventRequest): Promise<EventDto> {
 }
 
 export async function updateEvent(id: string, data: UpdateEventRequest): Promise<EventDto> {
-  const res = await fetch(`${BASE}/${id}`, {
+  const res = await apiFetch(`${BASE}/${id}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
   if (!res.ok) {
@@ -72,20 +71,19 @@ export async function updateEvent(id: string, data: UpdateEventRequest): Promise
 }
 
 export async function deleteEvent(id: string): Promise<void> {
-  const res = await fetch(`${BASE}/${id}`, { method: 'DELETE' });
+  const res = await apiFetch(`${BASE}/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to delete event: ${res.statusText}`);
 }
 
 export async function getEventAttendees(eventId: string): Promise<UserDto[]> {
-  const res = await fetch(`${BASE}/${eventId}/attendees`);
+  const res = await apiFetch(`${BASE}/${eventId}/attendees`);
   if (!res.ok) throw new Error(`Failed to fetch attendees: ${res.statusText}`);
   return res.json();
 }
 
 export async function registerForEvent(eventId: string, userId: string): Promise<void> {
-  const res = await fetch(`${BASE}/${eventId}/register`, {
+  const res = await apiFetch(`${BASE}/${eventId}/register`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ userId }),
   });
   if (!res.ok) throw new Error(`Failed to register for event: ${res.statusText}`);

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,4 +1,5 @@
-import { config } from '../config';
+﻿import { config } from '../config';
+import { apiFetch } from './apiClient';
 
 export interface UserDto {
   id: string;
@@ -30,26 +31,13 @@ export async function registerUser(data: RegisterRequest): Promise<UserDto> {
 }
 
 export async function getUser(id: string): Promise<UserDto> {
-  const res = await fetch(`${BASE}/${id}`);
+  const res = await apiFetch(`${BASE}/${id}`);
   if (!res.ok) throw new Error(`Failed to fetch user: ${res.statusText}`);
   return res.json();
 }
 
 export async function getUsers(page = 1, pageSize = 20): Promise<UserDto[]> {
-  const res = await fetch(`${BASE}?page=${page}&pageSize=${pageSize}`);
+  const res = await apiFetch(`${BASE}?page=${page}&pageSize=${pageSize}`);
   if (!res.ok) throw new Error(`Failed to fetch users: ${res.statusText}`);
-  return res.json();
-}
-
-export async function loginUser(email: string, password: string): Promise<UserDto> {
-  const res = await fetch(`${config.apiUrl}/api/auth/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password }),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || `Login failed: ${res.statusText}`);
-  }
   return res.json();
 }

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,5 +1,5 @@
-import { Outlet, NavLink, useNavigate } from 'react-router-dom';
-import type { UserDto } from '../api/users';
+﻿import { Outlet, NavLink, useNavigate } from 'react-router-dom';
+import { clearToken, getUser } from '../api/auth';
 
 const navLinkStyle = ({ isActive }: { isActive: boolean }): React.CSSProperties => ({
   color: isActive ? '#7eb3ff' : '#ccc',
@@ -11,11 +11,10 @@ const navLinkStyle = ({ isActive }: { isActive: boolean }): React.CSSProperties 
 
 export function AppLayout() {
   const navigate = useNavigate();
-  const raw = localStorage.getItem('currentUser');
-  const currentUser: UserDto | null = raw ? (JSON.parse(raw) as UserDto) : null;
+  const currentUser = getUser();
 
   function handleLogout() {
-    localStorage.removeItem('currentUser');
+    clearToken();
     navigate('/login');
   }
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+﻿import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { loginUser } from '../api/users';
+import { login, setToken, setUser } from '../api/auth';
 
 interface FormState {
   email: string;
@@ -61,9 +61,10 @@ export function LoginPage() {
     setSubmitting(true);
     setApiError(null);
     try {
-      const user = await loginUser(form.email.trim(), form.password);
-      localStorage.setItem('currentUser', JSON.stringify(user));
-      navigate('/profile');
+      const res = await login(form.email.trim(), form.password);
+      setToken(res.token);
+      setUser(res);
+      navigate('/events');
     } catch (e) {
       setApiError((e as Error).message);
     } finally {

--- a/src/LanManager.Api/Controllers/AuthController.cs
+++ b/src/LanManager.Api/Controllers/AuthController.cs
@@ -1,0 +1,71 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using LanManager.Data.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+
+namespace LanManager.Api.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IConfiguration _config;
+
+    public AuthController(UserManager<ApplicationUser> userManager, IConfiguration config)
+    {
+        _userManager = userManager;
+        _config = config;
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    {
+        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (user == null || !await _userManager.CheckPasswordAsync(user, request.Password))
+            return Unauthorized(new { message = "Invalid email or password." });
+
+        var roles = await _userManager.GetRolesAsync(user);
+        var token = GenerateToken(user, roles);
+
+        return Ok(new LoginResponse(
+            token,
+            user.Id,
+            user.Name,
+            user.Email ?? string.Empty,
+            roles.ToList()
+        ));
+    }
+
+    private string GenerateToken(ApplicationUser user, IList<string> roles)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var expiry = DateTime.UtcNow.AddMinutes(double.Parse(_config["Jwt:ExpiryMinutes"] ?? "480"));
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email ?? string.Empty),
+            new("name", user.Name),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+        };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+
+        var token = new JwtSecurityToken(
+            issuer: _config["Jwt:Issuer"],
+            audience: _config["Jwt:Audience"],
+            claims: claims,
+            expires: expiry,
+            signingCredentials: creds
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+
+public record LoginRequest(string Email, string Password);
+public record LoginResponse(string Token, Guid UserId, string Name, string Email, List<string> Roles);

--- a/src/LanManager.Api/Controllers/CheckInController.cs
+++ b/src/LanManager.Api/Controllers/CheckInController.cs
@@ -1,7 +1,8 @@
-using LanManager.Api.DTOs;
+﻿using LanManager.Api.DTOs;
 using LanManager.Api.Hubs;
 using LanManager.Data;
 using LanManager.Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
@@ -17,6 +18,7 @@ public class CheckInController(
     IHubContext<AttendanceHub> hubContext) : ControllerBase
 {
     [HttpPost("checkin")]
+    [Authorize(Roles = "Operator,Admin")]
     public async Task<ActionResult<CheckInDto>> CheckIn(Guid eventId, [FromBody] CheckInRequest request)
     {
         var ev = await db.Events.FindAsync(eventId);
@@ -53,6 +55,7 @@ public class CheckInController(
     }
 
     [HttpPost("checkout")]
+    [Authorize(Roles = "Operator,Admin")]
     public async Task<ActionResult<CheckInDto>> CheckOut(Guid eventId, [FromBody] CheckInRequest request)
     {
         var record = await db.CheckInRecords
@@ -72,6 +75,7 @@ public class CheckInController(
     }
 
     [HttpGet("attendance")]
+    [Authorize(Roles = "Organizer,Operator,Admin")]
     public async Task<ActionResult<IEnumerable<AttendanceDto>>> GetAttendance(Guid eventId)
     {
         var ev = await db.Events.FindAsync(eventId);

--- a/src/LanManager.Api/Controllers/DoorPassController.cs
+++ b/src/LanManager.Api/Controllers/DoorPassController.cs
@@ -1,6 +1,7 @@
-using LanManager.Api.DTOs;
+﻿using LanManager.Api.DTOs;
 using LanManager.Data;
 using LanManager.Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -10,6 +11,7 @@ namespace LanManager.Api.Controllers;
 
 [ApiController]
 [Route("api/events/{eventId:guid}")]
+[Authorize(Roles = "Operator,Admin")]
 public class DoorPassController(LanManagerDbContext db, UserManager<ApplicationUser> userManager) : ControllerBase
 {
     [HttpGet("attendees/{userId:guid}/qrcode")]

--- a/src/LanManager.Api/Controllers/EventsController.cs
+++ b/src/LanManager.Api/Controllers/EventsController.cs
@@ -1,6 +1,7 @@
 using LanManager.Api.DTOs;
 using LanManager.Data;
 using LanManager.Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,6 +12,7 @@ namespace LanManager.Api.Controllers;
 public class EventsController(LanManagerDbContext db) : ControllerBase
 {
     [HttpGet]
+    [Authorize]
     public async Task<ActionResult<IEnumerable<EventDto>>> GetAll(
         [FromQuery] EventStatus? status,
         [FromQuery] string? sort)
@@ -31,6 +33,7 @@ public class EventsController(LanManagerDbContext db) : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
+    [Authorize]
     public async Task<ActionResult<EventDto>> GetById(Guid id)
     {
         var ev = await db.Events.FindAsync(id);
@@ -39,6 +42,7 @@ public class EventsController(LanManagerDbContext db) : ControllerBase
     }
 
     [HttpPost]
+    [Authorize(Roles = "Admin,Organizer")]
     public async Task<ActionResult<EventDto>> Create([FromBody] CreateEventRequest request)
     {
         var ev = new Event
@@ -59,6 +63,7 @@ public class EventsController(LanManagerDbContext db) : ControllerBase
     }
 
     [HttpPut("{id:guid}")]
+    [Authorize(Roles = "Admin,Organizer")]
     public async Task<ActionResult<EventDto>> Update(Guid id, [FromBody] UpdateEventRequest request)
     {
         var ev = await db.Events.FindAsync(id);
@@ -77,6 +82,7 @@ public class EventsController(LanManagerDbContext db) : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> Delete(Guid id)
     {
         var ev = await db.Events.FindAsync(id);

--- a/src/LanManager.Api/Controllers/RegistrationsController.cs
+++ b/src/LanManager.Api/Controllers/RegistrationsController.cs
@@ -1,6 +1,7 @@
-using LanManager.Api.DTOs;
+﻿using LanManager.Api.DTOs;
 using LanManager.Data;
 using LanManager.Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -12,6 +13,7 @@ namespace LanManager.Api.Controllers;
 public class RegistrationsController(LanManagerDbContext db, UserManager<ApplicationUser> userManager) : ControllerBase
 {
     [HttpPost("register")]
+    [Authorize(Roles = "Attendee,Admin")]
     public async Task<ActionResult<RegistrationDto>> Register(Guid eventId, [FromBody] RegisterForEventRequest request)
     {
         var ev = await db.Events.FindAsync(eventId);
@@ -44,6 +46,7 @@ public class RegistrationsController(LanManagerDbContext db, UserManager<Applica
     }
 
     [HttpGet("attendees")]
+    [Authorize]
     public async Task<ActionResult<IEnumerable<RegistrationDto>>> GetAttendees(Guid eventId)
     {
         var ev = await db.Events.FindAsync(eventId);

--- a/src/LanManager.Api/Controllers/UsersController.cs
+++ b/src/LanManager.Api/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
-using LanManager.Api.DTOs;
+﻿using LanManager.Api.DTOs;
 using LanManager.Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +12,7 @@ namespace LanManager.Api.Controllers;
 public class UsersController(UserManager<ApplicationUser> userManager) : ControllerBase
 {
     [HttpPost("register")]
+    [AllowAnonymous]
     public async Task<ActionResult<UserDto>> Register([FromBody] CreateUserRequest request)
     {
         var user = new ApplicationUser
@@ -29,6 +31,7 @@ public class UsersController(UserManager<ApplicationUser> userManager) : Control
     }
 
     [HttpGet("{id:guid}")]
+    [Authorize]
     public async Task<ActionResult<UserDto>> GetById(Guid id)
     {
         var user = await userManager.FindByIdAsync(id.ToString());
@@ -37,6 +40,7 @@ public class UsersController(UserManager<ApplicationUser> userManager) : Control
     }
 
     [HttpGet]
+    [Authorize(Roles = "Admin,Organizer")]
     public async Task<ActionResult<PagedResult<UserDto>>> GetAll(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 20)

--- a/src/LanManager.Api/LanManager.Api.csproj
+++ b/src/LanManager.Api/LanManager.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.*" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/LanManager.Api/Program.cs
+++ b/src/LanManager.Api/Program.cs
@@ -1,9 +1,12 @@
+using System.Text;
 using LanManager.Api.Hubs;
 using LanManager.Api.Services;
 using LanManager.Data;
 using LanManager.Data.Models;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,6 +31,27 @@ builder.Services.AddIdentityCore<ApplicationUser>()
     .AddRoles<IdentityRole<Guid>>()
     .AddEntityFrameworkStores<LanManagerDbContext>();
 
+var jwtKey = builder.Configuration["Jwt:Key"] ?? throw new InvalidOperationException("Jwt:Key not configured");
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Audience"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
+    };
+});
+builder.Services.AddAuthorization();
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -37,6 +61,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseCors();
+app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 app.MapHub<AttendanceHub>("/hubs/attendance");

--- a/src/LanManager.Api/appsettings.Development.json
+++ b/src/LanManager.Api/appsettings.Development.json
@@ -7,5 +7,11 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=LitnPakke\\MSSQLSERVER01;Initial Catalog=LanManager_Squad;Integrated Security=True;Trust Server Certificate=True"
+  },
+  "Jwt": {
+    "Key": "dev-secret-key-min-32-chars-long!!",
+    "Issuer": "LanManager.Api",
+    "Audience": "LanManager.Clients",
+    "ExpiryMinutes": 480
   }
 }

--- a/src/LanManager.Api/appsettings.json
+++ b/src/LanManager.Api/appsettings.json
@@ -8,5 +8,11 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=lanmanager.db"
+  },
+  "Jwt": {
+    "Key": "",
+    "Issuer": "LanManager.Api",
+    "Audience": "LanManager.Clients",
+    "ExpiryMinutes": 480
   }
 }


### PR DESCRIPTION
## Summary

Implements JWT-based authentication and role-based authorization across the full stack.

## Backend changes
- **NuGet**: Added Microsoft.AspNetCore.Authentication.JwtBearer
- **Config**: JWT settings in ppsettings.Development.json (key, issuer, audience, expiry); placeholder in ppsettings.json
- **Program.cs**: Wired AddAuthentication + AddJwtBearer after Identity setup; added UseAuthentication() before UseAuthorization()
- **AuthController**: POST /api/auth/login — validates credentials, returns JWT + user info + roles
- **Role-based [Authorize] on all controllers**:
  | Endpoint | Roles |
  |---|---|
  | GET /api/events | Authenticated |
  | POST/PUT /api/events | Admin, Organizer |
  | DELETE /api/events/{id} | Admin |
  | GET /api/users | Admin, Organizer |
  | POST /api/users/register | Anonymous |
  | POST /api/events/{id}/register | Attendee, Admin |
  | POST checkin/checkout | Operator, Admin |
  | GET attendance | Organizer, Operator, Admin |
  | DoorPassController (all) | Operator, Admin |

## Frontend changes
- **pi/auth.ts**: login(), getToken/setToken/clearToken, getUser/setUser
- **pi/apiClient.ts**: piFetch() helper — injects Authorization: Bearer <token>, redirects to /login on 401
- **pi/events.ts, ttendance.ts, doorpass.ts**: switched from raw etch to piFetch
- **pi/users.ts**: egisterUser stays anonymous (etch), getUser/getUsers use piFetch; removed loginUser (replaced by uth.ts)
- **LoginPage.tsx**: uses login() from uth.ts, stores token via setToken/setUser, navigates to /events
- **AppLayout.tsx**: reads user from getUser() (jwt_user), logout calls clearToken()

## Builds
- dotnet build ✅ 0 warnings, 0 errors
- 
pm run build ✅ clean

Closes #25