### PR TITLE
fix(maui): QR scanner button not visible for Admin — timing race in CanAccessDoorScan

### DIFF
--- a/src/LanManager.Maui/ViewModels/CheckInViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/CheckInViewModel.cs
@@ -64,6 +64,11 @@ public partial class CheckInViewModel : ObservableObject, IQueryAttributable
     [RelayCommand]
     private async Task LoadDataAsync()
     {
+        // Re-evaluate role access each time the page loads in case CurrentUser
+        // was populated asynchronously after the ViewModel was constructed
+        CanAccessDoorScan = _authService.CurrentUser?.Roles
+            .Any(r => r == "Admin" || r == "Organizer") ?? false;
+
         IsLoading = true;
         
         try


### PR DESCRIPTION
Fixes #43 (MAUI side). Re-evaluate CanAccessDoorScan at the start of LoadDataAsync so it always reflects current auth state when the page loads. Keeps constructor assignment for the fresh-login case.