### PR TITLE
feat(frontend): responsive layout, nav collapse, visual bug fixes

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -109,3 +109,10 @@ code {
   padding: 4px 8px;
   background: var(--code-bg);
 }
+
+.page-title {
+  font-size: 28px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text-h);
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,4 +1,5 @@
-﻿import { Outlet, NavLink, useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { Outlet, NavLink, useNavigate } from 'react-router-dom';
 import { clearToken, getUser } from '../api/auth';
 
 const navLinkStyle = ({ isActive }: { isActive: boolean }): React.CSSProperties => ({
@@ -12,28 +13,66 @@ const navLinkStyle = ({ isActive }: { isActive: boolean }): React.CSSProperties 
 export function AppLayout() {
   const navigate = useNavigate();
   const currentUser = getUser();
+  const [navOpen, setNavOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
+
+  useEffect(() => {
+    const handle = () => {
+      const mobile = window.innerWidth <= 768;
+      setIsMobile(mobile);
+      if (!mobile) setNavOpen(false);
+    };
+    window.addEventListener('resize', handle);
+    return () => window.removeEventListener('resize', handle);
+  }, []);
 
   function handleLogout() {
     clearToken();
     navigate('/login');
   }
 
+  const sidebarStyle: React.CSSProperties = {
+    width: 220,
+    background: '#1a1a2e',
+    color: '#fff',
+    padding: '1rem',
+    display: isMobile ? (navOpen ? 'flex' : 'none') : 'flex',
+    flexDirection: 'column',
+    position: isMobile ? 'fixed' : 'relative',
+    zIndex: isMobile ? 1000 : 'auto',
+    height: isMobile ? '100vh' : 'auto',
+    top: 0,
+    left: 0,
+    overflowY: 'auto',
+  };
+
   return (
     <div style={{ display: 'flex', minHeight: '100vh' }}>
-      <nav style={{ width: 220, background: '#1a1a2e', color: '#fff', padding: '1rem', display: 'flex', flexDirection: 'column' }}>
+      {/* Mobile overlay */}
+      {isMobile && navOpen && (
+        <div
+          onClick={() => setNavOpen(false)}
+          style={{
+            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+            zIndex: 999,
+          }}
+        />
+      )}
+
+      <nav style={sidebarStyle}>
         <h2 style={{ marginBottom: '1.5rem', color: '#fff' }}>LanManager</h2>
         <ul style={{ listStyle: 'none', padding: 0, flex: 1 }}>
-          <li><NavLink to="/" end style={navLinkStyle}>Dashboard</NavLink></li>
-          <li><NavLink to="/events" style={navLinkStyle}>Events</NavLink></li>
-          <li><NavLink to="/users" style={navLinkStyle}>Users</NavLink></li>
-          <li><NavLink to="/attendance" style={navLinkStyle}>Attendance</NavLink></li>
-          <li><NavLink to="/tournaments" style={navLinkStyle}>Tournaments</NavLink></li>
-          <li><NavLink to="/seating" style={navLinkStyle}>Seating</NavLink></li>
+          <li><NavLink to="/" end style={navLinkStyle} onClick={() => setNavOpen(false)}>Dashboard</NavLink></li>
+          <li><NavLink to="/events" style={navLinkStyle} onClick={() => setNavOpen(false)}>Events</NavLink></li>
+          <li><NavLink to="/users" style={navLinkStyle} onClick={() => setNavOpen(false)}>Users</NavLink></li>
+          <li><NavLink to="/attendance" style={navLinkStyle} onClick={() => setNavOpen(false)}>Attendance</NavLink></li>
+          <li><NavLink to="/tournaments" style={navLinkStyle} onClick={() => setNavOpen(false)}>Tournaments</NavLink></li>
+          <li><NavLink to="/seating" style={navLinkStyle} onClick={() => setNavOpen(false)}>Seating</NavLink></li>
         </ul>
         <div style={{ borderTop: '1px solid #333', paddingTop: '1rem', marginTop: 'auto' }}>
           {currentUser ? (
             <>
-              <NavLink to="/profile" style={navLinkStyle}>
+              <NavLink to="/profile" style={navLinkStyle} onClick={() => setNavOpen(false)}>
                 {currentUser.name}
               </NavLink>
               <button
@@ -45,13 +84,27 @@ export function AppLayout() {
             </>
           ) : (
             <>
-              <NavLink to="/register" style={navLinkStyle}>Register</NavLink>
-              <NavLink to="/login" style={navLinkStyle}>Sign In</NavLink>
+              <NavLink to="/register" style={navLinkStyle} onClick={() => setNavOpen(false)}>Register</NavLink>
+              <NavLink to="/login" style={navLinkStyle} onClick={() => setNavOpen(false)}>Sign In</NavLink>
             </>
           )}
         </div>
       </nav>
-      <main style={{ flex: 1, padding: '2rem' }}>
+
+      <main style={{ flex: 1, padding: '2rem', textAlign: 'left', minWidth: 0 }}>
+        {isMobile && (
+          <button
+            onClick={() => setNavOpen(v => !v)}
+            aria-label="Toggle navigation"
+            style={{
+              background: 'none', border: '1px solid #555', color: '#ccc',
+              fontSize: '1.2rem', cursor: 'pointer', padding: '4px 10px',
+              borderRadius: 4, marginBottom: '1rem', display: 'block',
+            }}
+          >
+            ☰
+          </button>
+        )}
         <Outlet />
       </main>
     </div>

--- a/frontend/src/pages/AttendancePage.tsx
+++ b/frontend/src/pages/AttendancePage.tsx
@@ -109,6 +109,7 @@ function LiveAttendanceTab({ eventId }: { eventId: string }) {
       )}
 
       {attendees.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
             <tr style={{ borderBottom: '1px solid #333', textAlign: 'left' }}>
@@ -127,6 +128,7 @@ function LiveAttendanceTab({ eventId }: { eventId: string }) {
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   );
@@ -174,6 +176,7 @@ function OutsideNowTab({ eventId }: { eventId: string }) {
       )}
 
       {users.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
             <tr style={{ borderBottom: '1px solid #333', textAlign: 'left' }}>
@@ -196,6 +199,7 @@ function OutsideNowTab({ eventId }: { eventId: string }) {
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   );
@@ -243,6 +247,7 @@ function DoorLogTab({ eventId }: { eventId: string }) {
 
       {pageRecords.length > 0 && (
         <>
+          <div style={{ overflowX: 'auto' }}>
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
               <tr style={{ borderBottom: '1px solid #333', textAlign: 'left' }}>
@@ -270,6 +275,7 @@ function DoorLogTab({ eventId }: { eventId: string }) {
               ))}
             </tbody>
           </table>
+          </div>
 
           {totalPages > 1 && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 16 }}>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 export function DashboardPage() {
   return (
     <div>
-      <h1>Dashboard</h1>
+      <h1 className="page-title" style={{ marginBottom: '1rem' }}>Dashboard</h1>
       <p>Welcome to LanManager. Select a section from the sidebar.</p>
     </div>
   );

--- a/frontend/src/pages/EventDetailPage.tsx
+++ b/frontend/src/pages/EventDetailPage.tsx
@@ -51,7 +51,7 @@ export function EventDetailPage() {
   if (!event) return <p>Event not found.</p>;
 
   return (
-    <div style={{ maxWidth: 700 }}>
+    <div style={{ maxWidth: 700, width: '100%' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.5rem' }}>
         <div>
           <button
@@ -60,9 +60,9 @@ export function EventDetailPage() {
           >
             ← Back to Events
           </button>
-          <h1 style={{ margin: 0 }}>{event.name}</h1>
+          <h1 className="page-title">{event.name}</h1>
         </div>
-        <div style={{ display: 'flex', gap: 8, marginTop: 32 }}>
+        <div style={{ display: 'flex', gap: 8, marginTop: 32, flexWrap: 'wrap' }}>
           <button
             onClick={() => navigate(`/events/${event.id}/edit`)}
             style={{ background: '#0d6efd', color: '#fff', border: 'none', padding: '8px 16px', borderRadius: 6, cursor: 'pointer' }}

--- a/frontend/src/pages/EventListPage.tsx
+++ b/frontend/src/pages/EventListPage.tsx
@@ -50,8 +50,8 @@ export function EventListPage() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
-        <h1 style={{ margin: 0 }}>Events</h1>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem', flexWrap: 'wrap', gap: '0.75rem' }}>
+        <h1 className="page-title">Events</h1>
         <button
           onClick={() => navigate('/events/new')}
           style={{ background: '#0d6efd', color: '#fff', border: 'none', padding: '8px 18px', borderRadius: 6, cursor: 'pointer', fontWeight: 600 }}
@@ -60,7 +60,7 @@ export function EventListPage() {
         </button>
       </div>
 
-      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem', alignItems: 'center' }}>
+      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem', alignItems: 'center', flexWrap: 'wrap' }}>
         <label htmlFor="status-filter" style={{ fontWeight: 500 }}>Status:</label>
         <select
           id="status-filter"
@@ -89,6 +89,7 @@ export function EventListPage() {
       )}
 
       {!loading && !error && events.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
             <tr style={{ borderBottom: '2px solid #dee2e6', textAlign: 'left' }}>
@@ -117,6 +118,7 @@ export function EventListPage() {
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/SeatingPage.tsx
+++ b/frontend/src/pages/SeatingPage.tsx
@@ -81,7 +81,7 @@ export function SeatingPage() {
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
-        <h1 style={{ margin: 0 }}>Seating Map</h1>
+        <h1 className="page-title">Seating Map</h1>
         <span style={{ color: '#aaa', fontSize: '0.9rem' }}>{assignedCount}/{seats.length} seats assigned</span>
         {canSetup && (
           <button onClick={() => setShowSetup(v => !v)}
@@ -113,9 +113,9 @@ export function SeatingPage() {
       {error && <p style={{ color: '#f66', marginBottom: '1rem' }}>Error: {error}</p>}
       {loading && <p style={{ color: '#aaa' }}>Loading…</p>}
 
-      <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start' }}>
+      <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start', flexWrap: 'wrap' }}>
         {/* SVG Map */}
-        <div style={{ flex: 1, overflowX: 'auto' }}>
+        <div style={{ flex: 1, overflowX: 'auto', minWidth: 280 }}>
           {seats.length === 0 && !loading ? (
             <div style={{ color: '#aaa', padding: '3rem', textAlign: 'center', border: '2px dashed #333', borderRadius: 8 }}>
               No seats configured.{canSetup ? ' Use ⚙ Setup Grid to create seats.' : ''}
@@ -151,7 +151,7 @@ export function SeatingPage() {
         </div>
 
         {/* Right panel */}
-        <div style={{ width: 280, flexShrink: 0 }}>
+        <div style={{ width: 280, flexShrink: 0, minWidth: 240, flex: '1 1 240px' }}>
           {selectedSeat && (
             <div style={{ background: '#1a1a2e', borderRadius: 8, padding: '1rem', marginBottom: '1rem', border: `1px solid ${selectedSeat.assignedUserId ? '#c0392b' : '#3498db'}` }}>
               <strong>Seat {selectedSeat.label}</strong>

--- a/frontend/src/pages/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage.tsx
@@ -36,8 +36,8 @@ function TournamentListView({ eventId, onSelect }: { eventId: string; onSelect: 
 
   return (
     <div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem' }}>
-        <h1 style={{ margin: 0 }}>Tournaments</h1>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
+        <h1 className="page-title">Tournaments</h1>
         {canManage && (
           <button onClick={() => setShowCreate(true)}
             style={{ padding: '8px 16px', background: '#3498db', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer' }}>
@@ -186,7 +186,7 @@ function BracketView({ eventId, tournamentId, onBack }:
           style={{ background: 'none', border: '1px solid #333', color: '#aaa', padding: '6px 12px', borderRadius: 6, cursor: 'pointer' }}>
           ← Back
         </button>
-        <h1 style={{ margin: 0 }}>{bracket?.name ?? 'Loading…'}</h1>
+        <h1 className="page-title">{bracket?.name ?? 'Loading…'}</h1>
         {bracket && (
           <span style={{ background: bracket.status === 'Completed' ? '#2ecc71' : '#f0a500',
             color: '#000', borderRadius: 999, padding: '2px 10px', fontSize: '0.8rem', fontWeight: 600 }}>

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -25,7 +25,7 @@ export function UsersPage() {
 
   return (
     <div>
-      <h1 style={{ marginBottom: '1.5rem' }}>Users</h1>
+      <h1 className="page-title" style={{ marginBottom: '1.5rem' }}>Users</h1>
 
       {loading && <p>Loading users…</p>}
       {error && <p style={{ color: 'red' }}>Error: {error}</p>}
@@ -35,6 +35,7 @@ export function UsersPage() {
       )}
 
       {!loading && !error && users.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
             <tr style={{ borderBottom: '2px solid #dee2e6', textAlign: 'left' }}>
@@ -53,6 +54,7 @@ export function UsersPage() {
             ))}
           </tbody>
         </table>
+        </div>
       )}
 
       {!loading && !error && (


### PR DESCRIPTION
Fixes responsive layout and visual bugs in the React frontend. Closes #50

Bug 1: Add text-align left to main in AppLayout to prevent #root centering bleeding into app.
Bug 2: Responsive sidebar with hamburger toggle, isMobile/navOpen state, overlay and auto-close on resize.
Bug 3: SeatingPage flex container uses flexWrap wrap so right panel wraps on narrow screens.
Bug 4: Add .page-title CSS class (28px) and apply to all page h1 elements.
Bug 5: Wrap tables in overflowX auto, add flexWrap wrap to flex rows, fix hard-coded widths.

npm run build passes with no TypeScript errors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>