### PR TITLE
feat(maui): attendee QR code, hub page, and equipment borrowing scan

### DIFF
--- a/src/LanManager.Maui/ViewModels/MainViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/MainViewModel.cs
@@ -22,10 +22,14 @@ public partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private string _statusMessage = string.Empty;
 
+    [ObservableProperty]
+    private bool _isAttendee;
+
     public MainViewModel(ApiService apiService, AuthService authService)
     {
         _apiService = apiService;
         _authService = authService;
+        IsAttendee = _authService.CurrentUser?.Roles.Contains("Attendee") ?? false;
     }
 
     [RelayCommand]
@@ -53,6 +57,8 @@ public partial class MainViewModel : ObservableObject
                 StatusMessage = string.Empty;
                 SelectedEvent = Events.FirstOrDefault();
             }
+
+            IsAttendee = _authService.CurrentUser?.Roles.Contains("Attendee") ?? false;
         }
         catch (Exception ex)
         {
@@ -80,5 +86,17 @@ public partial class MainViewModel : ObservableObject
             await Shell.Current.GoToAsync($"AttendeeHubPage?eventId={SelectedEvent.Id}");
         else
             await Shell.Current.GoToAsync($"//CheckInPage?eventId={SelectedEvent.Id}");
+    }
+
+    [RelayCommand]
+    private async Task GoToAttendeeHubAsync()
+    {
+        if (SelectedEvent == null)
+        {
+            StatusMessage = "Please select an event first";
+            return;
+        }
+
+        await Shell.Current.GoToAsync($"AttendeeHubPage?eventId={SelectedEvent.Id}");
     }
 }

--- a/src/LanManager.Maui/Views/MainPage.xaml
+++ b/src/LanManager.Maui/Views/MainPage.xaml
@@ -13,6 +13,7 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Label Grid.Row="0"
@@ -48,6 +49,16 @@
                 Text="Select Event"
                 Command="{Binding SelectEventCommand}"
                 IsEnabled="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}"
+                FontSize="18"
+                Padding="20"
+                Margin="0,10,0,0" />
+
+        <Button Grid.Row="5"
+                Text="🏠 My Hub"
+                Command="{Binding GoToAttendeeHubCommand}"
+                IsVisible="{Binding IsAttendee}"
+                BackgroundColor="#8e44ad" TextColor="White"
+                CornerRadius="6"
                 FontSize="18"
                 Padding="20"
                 Margin="0,10,0,0" />


### PR DESCRIPTION
Closes #44, #46, #49

## Changes

### Feature 1 — AttendeeQrPage (#44)
- New AttendeeQrViewModel fetches PNG bytes from /api/events/{eventId}/attendees/{userId}/qrcode and displays as ImageSource
- New AttendeeQrPage.xaml shows QR image in white frame on dark background with user name header

### Feature 2 — AttendeeHubPage (#46)
- New AttendeeHubViewModel loads seat assignment and open tournaments in parallel
- New AttendeeHubPage.xaml shows seat card, QR code button, equipment borrow button, and tournament enrolment list
- EnrolCommand calls SelfEnrolTournamentAsync and handles 409/400 gracefully

### Feature 3 — EquipmentScanPage (#49)
- New EquipmentScanViewModel with 2 s cooldown; calls BorrowEquipmentAsync on scan, shows active loans
- New EquipmentScanPage.xaml reuses ZXing camera pattern from DoorScanPage

### Plumbing
- ApiService: new DTOs (SeatDto, TournamentDto, EquipmentLoanDto) + 6 new methods
- ValueConverters: IsNotNullConverter, IsZeroConverter
- App.xaml: registers new converters
- AppShell.xaml.cs: registers 3 new routes
- MauiProgram.cs: registers 3 new pages + view models
- MainViewModel: injects AuthService, adds IsAttendee property and GoToAttendeeHubCommand
- MainPage.xaml: adds 'My Hub' button visible only when IsAttendee is true