### PR TITLE
feat: tabbed AttendancePage with Outside Now and Door Log views

### DIFF
--- a/frontend/src/api/doorpass.ts
+++ b/frontend/src/api/doorpass.ts
@@ -1,0 +1,30 @@
+import { config } from '../config';
+
+export interface OutsideUserDto {
+  userId: string;
+  userName: string;
+  exitedAt: string;
+}
+
+export interface DoorPassDto {
+  id: string;
+  eventId: string;
+  userId: string;
+  userName: string;
+  direction: 'Exit' | 'Entry';
+  scannedAt: string;
+}
+
+const BASE = `${config.apiUrl}/api/events`;
+
+export async function getOutside(eventId: string): Promise<OutsideUserDto[]> {
+  const res = await fetch(`${BASE}/${eventId}/outside`);
+  if (!res.ok) throw new Error(`Failed to fetch outside users: ${res.statusText}`);
+  return res.json();
+}
+
+export async function getDoorLog(eventId: string, page = 1, pageSize = 50): Promise<DoorPassDto[]> {
+  const res = await fetch(`${BASE}/${eventId}/door-log?page=${page}&pageSize=${pageSize}`);
+  if (!res.ok) throw new Error(`Failed to fetch door log: ${res.statusText}`);
+  return res.json();
+}

--- a/frontend/src/pages/AttendancePage.tsx
+++ b/frontend/src/pages/AttendancePage.tsx
@@ -4,6 +4,8 @@ import { HubConnectionBuilder, HubConnectionState } from '@microsoft/signalr';
 import { config } from '../config';
 import { getAttendance } from '../api/attendance';
 import type { AttendanceDto } from '../api/attendance';
+import { getOutside, getDoorLog } from '../api/doorpass';
+import type { OutsideUserDto, DoorPassDto } from '../api/doorpass';
 
 interface CheckedInBroadcast {
   eventId: string;
@@ -19,21 +21,24 @@ interface CheckedOutBroadcast {
   checkedOutAt: string;
 }
 
-export function AttendancePage() {
-  const [searchParams] = useSearchParams();
-  const eventId = searchParams.get('eventId');
+function elapsed(isoDate: string): string {
+  const mins = Math.floor((Date.now() - new Date(isoDate).getTime()) / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m ago`;
+}
 
+// ─── Live Tab ────────────────────────────────────────────────────────────────
+
+function LiveAttendanceTab({ eventId }: { eventId: string }) {
   const [attendees, setAttendees] = useState<AttendanceDto[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hubStatus, setHubStatus] = useState<string>('Connecting…');
 
   useEffect(() => {
-    if (!eventId) return;
-
     setLoading(true);
     setError(null);
-
     getAttendance(eventId)
       .then(setAttendees)
       .catch((err: Error) => setError(err.message))
@@ -47,7 +52,7 @@ export function AttendancePage() {
       .build();
 
     connection.on('UserCheckedIn', (broadcast: CheckedInBroadcast) => {
-      if (eventId && broadcast.eventId !== eventId) return;
+      if (broadcast.eventId !== eventId) return;
       setAttendees(prev => {
         if (prev.some(a => a.userId === broadcast.userId)) return prev;
         return [...prev, {
@@ -59,7 +64,7 @@ export function AttendancePage() {
     });
 
     connection.on('UserCheckedOut', (broadcast: CheckedOutBroadcast) => {
-      if (eventId && broadcast.eventId !== eventId) return;
+      if (broadcast.eventId !== eventId) return;
       setAttendees(prev => prev.filter(a => a.userId !== broadcast.userId));
     });
 
@@ -75,41 +80,23 @@ export function AttendancePage() {
       }
     });
 
-    return () => {
-      connection.stop();
-    };
+    return () => { connection.stop(); };
   }, [eventId]);
-
-  if (!eventId) {
-    return (
-      <div>
-        <h1>Live Attendance</h1>
-        <p style={{ color: '#aaa' }}>Select an event to view attendance.</p>
-      </div>
-    );
-  }
 
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem' }}>
-        <h1 style={{ margin: 0 }}>Live Attendance</h1>
+        <h2 style={{ margin: 0 }}>Live Attendance</h2>
         <span style={{
           background: hubStatus === 'Live' ? '#2a7a2a' : '#555',
-          color: '#fff',
-          borderRadius: '999px',
-          padding: '2px 12px',
-          fontSize: '0.8rem',
-          fontWeight: 600,
+          color: '#fff', borderRadius: '999px', padding: '2px 12px',
+          fontSize: '0.8rem', fontWeight: 600,
         }}>
           {hubStatus}
         </span>
         <span style={{
-          background: '#1a1a2e',
-          color: '#7eb3ff',
-          borderRadius: '999px',
-          padding: '2px 12px',
-          fontSize: '0.85rem',
-          fontWeight: 600,
+          background: '#1a1a2e', color: '#7eb3ff', borderRadius: '999px',
+          padding: '2px 12px', fontSize: '0.85rem', fontWeight: 600,
         }}>
           {attendees.length} checked in
         </span>
@@ -117,7 +104,6 @@ export function AttendancePage() {
 
       {loading && <p style={{ color: '#aaa' }}>Loading attendance…</p>}
       {error && <p style={{ color: '#f66' }}>Error: {error}</p>}
-
       {!loading && !error && attendees.length === 0 && (
         <p style={{ color: '#aaa' }}>0 people checked in.</p>
       )}
@@ -142,6 +128,213 @@ export function AttendancePage() {
           </tbody>
         </table>
       )}
+    </div>
+  );
+}
+
+// ─── Outside Now Tab ─────────────────────────────────────────────────────────
+
+function OutsideNowTab({ eventId }: { eventId: string }) {
+  const [users, setUsers] = useState<OutsideUserDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    function fetchData() {
+      setLoading(true);
+      getOutside(eventId)
+        .then(data => { if (!cancelled) setUsers(data); })
+        .catch((err: Error) => { if (!cancelled) setError(err.message); })
+        .finally(() => { if (!cancelled) setLoading(false); });
+    }
+
+    fetchData();
+    const timer = setInterval(fetchData, 30000);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [eventId]);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem' }}>
+        <h2 style={{ margin: 0 }}>Outside Now</h2>
+        <span style={{
+          background: '#1a1a2e', color: '#7eb3ff', borderRadius: '999px',
+          padding: '2px 12px', fontSize: '0.85rem', fontWeight: 600,
+        }}>
+          {users.length} outside
+        </span>
+      </div>
+
+      {loading && <p style={{ color: '#aaa' }}>Loading…</p>}
+      {error && <p style={{ color: '#f66' }}>Error: {error}</p>}
+      {!loading && !error && users.length === 0 && (
+        <p style={{ color: '#aaa' }}>Everyone is inside.</p>
+      )}
+
+      {users.length > 0 && (
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ borderBottom: '1px solid #333', textAlign: 'left' }}>
+              <th style={{ padding: '8px 12px' }}>Name</th>
+              <th style={{ padding: '8px 12px' }}>Exited At</th>
+              <th style={{ padding: '8px 12px' }}>Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map(u => (
+              <tr key={u.userId} style={{ borderBottom: '1px solid #222' }}>
+                <td style={{ padding: '8px 12px' }}>{u.userName}</td>
+                <td style={{ padding: '8px 12px', color: '#aaa', fontSize: '0.9rem' }}>
+                  {new Date(u.exitedAt).toLocaleTimeString()}
+                </td>
+                <td style={{ padding: '8px 12px', color: '#f0a500', fontSize: '0.9rem' }}>
+                  {elapsed(u.exitedAt)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+// ─── Door Log Tab ─────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 20;
+
+function DoorLogTab({ eventId }: { eventId: string }) {
+  const [records, setRecords] = useState<DoorPassDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    getDoorLog(eventId)
+      .then(setRecords)
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [eventId]);
+
+  const totalPages = Math.max(1, Math.ceil(records.length / PAGE_SIZE));
+  const pageRecords = records.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem' }}>
+        <h2 style={{ margin: 0 }}>Door Log</h2>
+        <span style={{
+          background: '#1a1a2e', color: '#7eb3ff', borderRadius: '999px',
+          padding: '2px 12px', fontSize: '0.85rem', fontWeight: 600,
+        }}>
+          {records.length} entries
+        </span>
+      </div>
+
+      {loading && <p style={{ color: '#aaa' }}>Loading…</p>}
+      {error && <p style={{ color: '#f66' }}>Error: {error}</p>}
+      {!loading && !error && records.length === 0 && (
+        <p style={{ color: '#aaa' }}>No door passes recorded.</p>
+      )}
+
+      {pageRecords.length > 0 && (
+        <>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid #333', textAlign: 'left' }}>
+                <th style={{ padding: '8px 12px' }}>Direction</th>
+                <th style={{ padding: '8px 12px' }}>Name</th>
+                <th style={{ padding: '8px 12px' }}>Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pageRecords.map(r => (
+                <tr key={r.id} style={{ borderBottom: '1px solid #222' }}>
+                  <td style={{ padding: '8px 12px' }}>
+                    <span style={{
+                      color: r.direction === 'Exit' ? '#e74c3c' : '#2ecc71',
+                      fontWeight: 600,
+                    }}>
+                      {r.direction === 'Exit' ? '🚪 Exit' : '↩ Entry'}
+                    </span>
+                  </td>
+                  <td style={{ padding: '8px 12px' }}>{r.userName}</td>
+                  <td style={{ padding: '8px 12px', color: '#aaa', fontSize: '0.9rem' }}>
+                    {new Date(r.scannedAt).toLocaleTimeString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {totalPages > 1 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 16 }}>
+              <button
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page === 1}
+                style={{ padding: '6px 14px', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }}
+              >
+                ← Prev
+              </button>
+              <span style={{ color: '#aaa', fontSize: '0.9rem' }}>
+                Page {page} of {totalPages}
+              </span>
+              <button
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                style={{ padding: '6px 14px', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }}
+              >
+                Next →
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+export function AttendancePage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const eventId = searchParams.get('eventId') ?? '';
+  const tab = (searchParams.get('tab') ?? 'live') as 'live' | 'outside' | 'doorlog';
+
+  const setTab = (t: string) =>
+    setSearchParams(p => { p.set('tab', t); return p; });
+
+  if (!eventId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <p style={{ color: '#aaa' }}>Select an event to view attendance.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', borderBottom: '2px solid #eee', marginBottom: 16 }}>
+        {(['live', 'outside', 'doorlog'] as const).map(t => (
+          <button key={t} onClick={() => setTab(t)}
+            style={{
+              padding: '8px 20px',
+              fontWeight: tab === t ? 'bold' : 'normal',
+              borderBottom: tab === t ? '2px solid #3498db' : 'none',
+              background: 'none', border: 'none', cursor: 'pointer',
+            }}>
+            {t === 'live' ? '🟢 Live' : t === 'outside' ? '🚪 Outside Now' : '📋 Door Log'}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'live' && <LiveAttendanceTab eventId={eventId} />}
+      {tab === 'outside' && <OutsideNowTab eventId={eventId} />}
+      {tab === 'doorlog' && <DoorLogTab eventId={eventId} />}
     </div>
   );
 }

--- a/frontend/src/pages/EventDetailPage.tsx
+++ b/frontend/src/pages/EventDetailPage.tsx
@@ -70,6 +70,12 @@ export function EventDetailPage() {
             Edit
           </button>
           <button
+            onClick={() => navigate(`/attendance?eventId=${event.id}&tab=doorlog`)}
+            style={{ background: '#6c757d', color: '#fff', border: 'none', padding: '8px 16px', borderRadius: 6, cursor: 'pointer' }}
+          >
+            📋 Door Log
+          </button>
+          <button
             onClick={handleDelete}
             disabled={deleting}
             style={{ background: '#dc3545', color: '#fff', border: 'none', padding: '8px 16px', borderRadius: 6, cursor: 'pointer' }}


### PR DESCRIPTION
Refactors AttendancePage into three tabs: Live, Outside Now, and Door Log.

Closes #29

## Changes

**New API Module:**
- frontend/src/api/doorpass.ts with getOutside() and getDoorLog() functions
- OutsideUserDto and DoorPassDto type definitions

**Page Refactoring:**
- AttendancePage split into three tabs:
  - **Live Tab**: Preserves existing SignalR check-in board
  - **Outside Now Tab**: Polls /api/events/{id}/outside every 30s with elapsed time display
  - **Door Log Tab**: Fetches /api/events/{id}/door-log with client-side pagination (20 per page)
- Tab state driven by ?tab= URL param (live|outside|doorlog)

**Navigation:**
- Added Door Log button in EventDetailPage linking to attendance?tab=doorlog

## Features

- Live check-in board with SignalR updates
- Real-time outside user tracking with elapsed time
- Complete door pass history with direction indicators
- Clean tab-based UI for easy navigation