### PR TITLE
test: Playwright auth flow tests

### DIFF
--- a/.squad/agents/radagast/history.md
+++ b/.squad/agents/radagast/history.md
@@ -11,3 +11,7 @@
 
 ### 2026-04-08: Playwright E2E Infrastructure Setup (#71)
 **What:** Added Playwright config and e2e scaffolding in `frontend/`, including auth fixture (email/password selectors) and smoke tests. Tests run via `npm run test:e2e` and expect login to redirect to `/events`.
+
+### 2026-04-09: Auth flow Playwright coverage (#72)
+**What:** Added auth flow E2E checks for login form fields, invalid credentials, and unauthenticated route redirects. Valid-credential login is skipped pending a live API.
+

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Authentication', () => {
+  test('login page renders with email and password fields', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.locator('input[name="email"]')).toBeVisible();
+    await expect(page.locator('input[name="password"]')).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toBeVisible();
+  });
+
+  test('login with invalid credentials shows error', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'nobody@fake.invalid');
+    await page.fill('input[name="password"]', 'wrongpassword');
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test.skip('login with valid credentials redirects to dashboard', async ({ page }) => {
+    // Requires running API with known credentials.
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'testuser@example.com');
+    await page.fill('input[name="password"]', 'Test1234!');
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+
+  test('navigating to protected route while logged out redirects to login', async ({ page }) => {
+    await page.goto('/login');
+    await page.evaluate(() => {
+      localStorage.removeItem('jwt_token');
+      localStorage.removeItem('jwt_user');
+    });
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('navigating to /events while logged out redirects to login', async ({ page }) => {
+    await page.goto('/login');
+    await page.evaluate(() => {
+      localStorage.removeItem('jwt_token');
+      localStorage.removeItem('jwt_user');
+    });
+    await page.goto('/events');
+    await expect(page).toHaveURL(/\/login/);
+  });
+});


### PR DESCRIPTION
Closes #72

Auth flow E2E tests: login page renders, invalid credentials, protected route guards.
Depends on: #83 (Playwright infrastructure)