### PR TITLE
feat(frontend): Download Report button with section toggles for closed events

### DIFF
--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -88,3 +88,27 @@ export async function registerForEvent(eventId: string, userId: string): Promise
   });
   if (!res.ok) throw new Error(`Failed to register for event: ${res.statusText}`);
 }
+
+export async function downloadEventReport(
+  eventId: string,
+  sections: string[] = ['All']
+): Promise<void> {
+  const token = localStorage.getItem('jwt_token');
+  const sectionsParam = sections.join(',');
+  const response = await fetch(
+    `/api/events/${eventId}/report?sections=${sectionsParam}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to download report: ${response.status}`);
+  }
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `event-report.pdf`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/components/ReportDownloadButton.tsx
+++ b/frontend/src/components/ReportDownloadButton.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { downloadEventReport } from '../api/events';
+
+const ALL_SECTIONS = ['Registrations', 'CheckIns', 'Equipment', 'Tournaments'] as const;
+type Section = typeof ALL_SECTIONS[number];
+
+interface ReportDownloadButtonProps {
+  eventId: string;
+  eventStatus: string;
+  userRole: string;
+}
+
+export function ReportDownloadButton({ eventId, eventStatus, userRole }: ReportDownloadButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<Set<Section>>(new Set(ALL_SECTIONS));
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (eventStatus !== 'Closed') return null;
+  if (userRole !== 'Admin' && userRole !== 'Organizer') return null;
+
+  function toggle(section: Section) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(section)) {
+        next.delete(section);
+      } else {
+        next.add(section);
+      }
+      return next;
+    });
+  }
+
+  async function handleDownload() {
+    setError(null);
+    setDownloading(true);
+    try {
+      const sections = selected.size === ALL_SECTIONS.length
+        ? ['All']
+        : Array.from(selected);
+      await downloadEventReport(eventId, sections);
+      setOpen(false);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => setOpen(v => !v)}
+        className="btn-primary"
+        style={{ padding: '8px 16px', borderRadius: 6 }}
+      >
+        📄 Download Report
+      </button>
+
+      {open && (
+        <div style={{
+          marginTop: 8,
+          padding: '1rem',
+          background: 'var(--surface)',
+          border: '1px solid rgba(0,212,255,0.2)',
+          borderRadius: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.5rem',
+          minWidth: 220,
+        }}>
+          <span style={{ color: 'var(--text)', fontWeight: 600, marginBottom: 4 }}>Sections</span>
+          {ALL_SECTIONS.map(section => (
+            <label
+              key={section}
+              style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', color: 'var(--text)' }}
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(section)}
+                onChange={() => toggle(section)}
+                style={{ accentColor: 'var(--cyan)' }}
+              />
+              {section}
+            </label>
+          ))}
+
+          {error && (
+            <span style={{ color: 'var(--danger)', fontSize: '0.85rem', marginTop: 4 }}>
+              {error}
+            </span>
+          )}
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <button
+              onClick={handleDownload}
+              disabled={downloading || selected.size === 0}
+              className="btn-primary"
+              style={{ padding: '6px 14px', borderRadius: 6, flex: 1 }}
+            >
+              {downloading ? '⏳ Downloading…' : 'Download'}
+            </button>
+            <button
+              onClick={() => { setOpen(false); setError(null); }}
+              className="btn-ghost"
+              style={{ padding: '6px 14px', borderRadius: 6 }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/EventDetailPage.tsx
+++ b/frontend/src/pages/EventDetailPage.tsx
@@ -4,6 +4,8 @@ import { getEvent, getEventAttendees, deleteEvent } from '../api/events';
 import type { EventDto } from '../api/events';
 import type { UserDto } from '../api/users';
 import { useEventContext } from '../context/EventContext';
+import { getUser } from '../api/auth';
+import { ReportDownloadButton } from '../components/ReportDownloadButton';
 
 const STATUS_COLORS: Record<string, { bg: string; color: string }> = {
   Draft:     { bg: 'rgba(90,90,128,0.2)',   color: '#9ca3c8' },
@@ -22,6 +24,9 @@ export function EventDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+
+  const currentUser = getUser();
+  const userRole = currentUser?.roles?.[0] ?? '';
 
   useEffect(() => {
     if (!id) return;
@@ -90,6 +95,11 @@ export function EventDetailPage() {
             style={{ padding: '8px 16px', borderRadius: 6 }}>
             🏆 Tournaments
           </button>
+          <ReportDownloadButton
+            eventId={event.id}
+            eventStatus={event.status}
+            userRole={userRole}
+          />
           <button
             onClick={handleDelete}
             disabled={deleting}


### PR DESCRIPTION
Closes #104

Adds downloadEventReport API function and ReportDownloadButton component. Visible only for Closed events to Admin/Organizer users. Supports section picker with all sections checked by default.