### PR TITLE
fix: Resolve empty PDF generation (~630-byte invalid file)

### DIFF
--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -1,5 +1,6 @@
 ﻿import { config } from '../config';
 import { apiFetch } from './apiClient';
+import { getToken } from './auth';
 import type { UserDto } from './users';
 
 export interface EventDto {
@@ -93,10 +94,10 @@ export async function downloadEventReport(
   eventId: string,
   sections: string[] = ['All']
 ): Promise<void> {
-  const token = localStorage.getItem('jwt_token');
+  const token = getToken();
   const sectionsParam = sections.join(',');
   const response = await fetch(
-    `/api/events/${eventId}/report?sections=${sectionsParam}`,
+    `${config.apiUrl}/api/events/${eventId}/report?sections=${sectionsParam}`,
     { headers: { Authorization: `Bearer ${token}` } }
   );
   if (!response.ok) {

--- a/src/LanManager.Api.Tests/Reports/EventReportPdfGeneratorTests.cs
+++ b/src/LanManager.Api.Tests/Reports/EventReportPdfGeneratorTests.cs
@@ -54,7 +54,7 @@ public class EventReportPdfGeneratorTests
         var bytes = generator.GeneratePdf(data);
 
         Assert.NotNull(bytes);
-        Assert.NotEmpty(bytes);
+        Assert.True(bytes.Length > 1024, $"PDF is too small ({bytes.Length} bytes); expected > 1 KB. Likely empty document or license issue.");
     }
 
     [Fact]


### PR DESCRIPTION
## Root Cause

downloadEventReport() in rontend/src/api/events.ts used a **relative URL** (/api/events/{id}/report) instead of the absolute API base URL used by every other API call.

In development, the Vite dev server has **no proxy configured** for /api routes. So the fetch request hit the Vite server, which returned the React SPA index.html (≈630 bytes) with a 200 OK status. Since esponse.ok was true, no error was thrown — the HTML was silently saved as a .pdf file, producing an unreadable document.

## Changes

| File | Change |
|------|--------|
| rontend/src/api/events.ts | Use \/api/events/... (absolute URL, consistent with all other calls); use getToken() helper instead of raw localStorage.getItem |
| src/LanManager.Api.Tests/Reports/EventReportPdfGeneratorTests.cs | Strengthen assertion: ytes.Length > 1024 instead of NotEmpty |

## Verification

- All 69 backend tests pass (1 skipped by design)
- Frontend builds clean (	sc -b && vite build)
- PDF generator produces valid multi-KB PDFs for events with data