### PR TITLE
fix: Resolve JSON deserialization error on event update

### DIFF
--- a/.squad/agents/merlin/history.md
+++ b/.squad/agents/merlin/history.md
@@ -9,6 +9,16 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+## Event Update JSON Deserialization Fix — squad/fix-event-update-dto
+Root cause: `UpdateEventRequest.Status` (and `CreateEventRequest.Status`) are typed as `EventStatus` (a C# enum). By default, `System.Text.Json` deserializes enums as integers, but the frontend sends string values (`"Active"`, `"Draft"`, etc.). Fix: registered `JsonStringEnumConverter` globally via `AddJsonOptions` in `Program.cs`. All 62 tests pass.
+
+**Pattern to remember:** Any C# enum in a DTO that is received from the React frontend needs `JsonStringEnumConverter` registered (globally or per-property), because the frontend always serialises enums as strings.
+
+## PDF Download Bug (2026-04-08) — PR #112
+Root cause: `downloadEventReport()` in `frontend/src/api/events.ts` used a relative URL (`/api/events/{id}/report`) while all other API functions use `${config.apiUrl}/api/...` (absolute). In development, Vite has no `/api` proxy, so the request hit the Vite server and returned the React SPA `index.html` (~630 bytes) with 200 OK. This HTML was saved as a `.pdf`, producing an invalid file. Fix: use absolute URL with `config.apiUrl` and `getToken()` helper. Strengthened test assertion to `bytes.Length > 1024`.
+
+**Pattern to remember:** Any new `fetch()` call in `frontend/src/api/` MUST use `${config.apiUrl}/api/...` (absolute), not a bare `/api/...` relative path. The Vite dev server has no proxy for `/api`.
+
 ## Issue #2 — EF Core data models (2026-04-05)
 Created Event, User, Registration, CheckInRecord entities. LanManagerDbContext in src/LanManager.Api/Data/. SQLite dev DB. Unique index on Registration(EventId, UserId). InitialCreate migration created. PR opened.
 

--- a/.squad/decisions/inbox/merlin-event-update-fix.md
+++ b/.squad/decisions/inbox/merlin-event-update-fix.md
@@ -1,0 +1,39 @@
+# Fix: JSON Deserialization Error on Event Update Endpoint
+
+**Date:** 2026-04-09  
+**Author:** Merlin  
+**Branch:** squad/fix-event-update-dto
+
+## Root Cause
+
+`UpdateEventRequest.Status` (and `CreateEventRequest.Status`) are typed as `EventStatus` — a C# enum.  
+By default, `System.Text.Json` (used by ASP.NET Core) deserializes enums as **integers**.  
+The React frontend sends the enum value as a **string** (e.g. `"Active"`, `"Draft"`).
+
+This mismatch caused a 400/deserialization error whenever the frontend called `PUT /api/events/{id}`.
+
+## Fix
+
+Added `JsonStringEnumConverter` globally in `Program.cs`:
+
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(opts =>
+        opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+```
+
+This enables both:
+- **Deserialisation** of incoming string enum values (`"Active"` → `EventStatus.Active`)
+- **Serialisation** of outgoing enum values as strings (consistent with how `EventDto.Status` was already returned as `.ToString()`)
+
+## Files Changed
+
+- `src/LanManager.Api/Program.cs` — added `using System.Text.Json.Serialization;` and `.AddJsonOptions(...)` to `AddControllers()`
+
+## Verification
+
+`dotnet build` clean; all 62 unit tests pass.
+
+## Impact
+
+Affects **both** `POST /api/events` (create) and `PUT /api/events/{id}` (update) since both DTOs had the same issue. No migration needed; no schema change.

--- a/src/LanManager.Api/Program.cs
+++ b/src/LanManager.Api/Program.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json.Serialization;
 using LanManager.Api.Hubs;
 using LanManager.Api.Services;
 using LanManager.Data;
@@ -12,7 +13,9 @@ QuestPDF.Settings.License = QuestPDF.Infrastructure.LicenseType.Community;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(opts =>
+        opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 builder.Services.AddSignalR();
 builder.Services.AddOpenApi();
 builder.Services.AddScoped<DataSeeder>();


### PR DESCRIPTION
## Root Cause

UpdateEventRequest.Status (and CreateEventRequest.Status) are typed as EventStatus (C# enum). By default, System.Text.Json expects enum values as **integers**. The React frontend always sends them as **strings** (e.g. \Active\`, \Draft\`), causing a 400 deserialization failure on PUT /api/events/{id}.

## Fix

Registered JsonStringEnumConverter globally in Program.cs:

\\\csharp
builder.Services.AddControllers()
    .AddJsonOptions(opts =>
        opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
\\\

## Verification

- dotnet build clean — 0 warnings, 0 errors
- All 62 unit tests pass