### PR TITLE
frontend: Display user names instead of emails in seating

### DIFF
--- a/frontend/src/api/attendance.ts
+++ b/frontend/src/api/attendance.ts
@@ -4,6 +4,7 @@ import { apiFetch } from './apiClient';
 export interface AttendanceDto {
   userId: string;
   userName: string;
+  name: string;
   checkedInAt: string;
 }
 

--- a/frontend/src/pages/AttendancePage.tsx
+++ b/frontend/src/pages/AttendancePage.tsx
@@ -12,6 +12,7 @@ interface CheckedInBroadcast {
   eventId: string;
   userId: string;
   userName: string;
+  name: string;
   checkedInAt: string;
 }
 
@@ -59,6 +60,7 @@ function LiveAttendanceTab({ eventId }: { eventId: string }) {
         return [...prev, {
           userId: broadcast.userId,
           userName: broadcast.userName,
+          name: broadcast.name,
           checkedInAt: broadcast.checkedInAt,
         }];
       });

--- a/frontend/src/pages/SeatingPage.tsx
+++ b/frontend/src/pages/SeatingPage.tsx
@@ -53,7 +53,7 @@ export function SeatingPage() {
   async function handleAssign(a: AttendanceDto) {
     if (!selectedSeat || selectedSeat.assignedUserId || !canManage) return;
     try {
-      const updated = await assignSeat(eventId, selectedSeat.id, a.userId, a.userName);
+      const updated = await assignSeat(eventId, selectedSeat.id, a.userId, a.name);
       setSeats(prev => prev.map(s => {
         if (s.assignedUserId === a.userId) return { ...s, assignedUserId: undefined, assignedUserName: undefined, assignedAt: undefined };
         if (s.id === updated.id) return updated;
@@ -237,8 +237,13 @@ export function SeatingPage() {
                 }}>
                   {hasSeat ? `Seat ${hasSeat.label}` : 'Unassigned'}
                 </div>
-                <div style={{ fontSize: '1rem', fontWeight: 500, color: '#fff' }}>
-                  {a.userName}
+                <div>
+                  <div style={{ fontSize: '1rem', fontWeight: 500, color: '#fff' }}>
+                    {a.name}
+                  </div>
+                  <div style={{ fontSize: '0.72rem', color: '#aaa', opacity: 0.7, marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {a.userName}
+                  </div>
                 </div>
               </div>
             );


### PR DESCRIPTION
## Problem
The seating page was showing email addresses where it should show display names.

## Changes
- Added 
ame: string field to AttendanceDto for display names  
- Updated SeatingPage to show name as primary text with email as smaller secondary text
- Updated AttendancePage SignalR handler to include name field from broadcasts
- Modified seat assignment to pass display name instead of email

## Testing
✅ Build passes
✅ TypeScript compilation successful

## Related
This PR complements the backend PR that adds the 
ame field to the API responses and SignalR broadcasts.

**Note:** Both PRs should be merged together for the feature to work properly.