### PR TITLE
fix: Resolve all warnings/errors and enable TreatWarningsAsErrors

### DIFF
--- a/.squad/agents/merlin/history.md
+++ b/.squad/agents/merlin/history.md
@@ -64,3 +64,25 @@ Added QuestPDF 2026.2.4 to LanManager.Api.csproj. Set `QuestPDF.Settings.License
 - `table.Header(header => {...})` for sticky header rows
 - `.Background(Colors.Grey.Darken2)` / `.Background(Colors.Grey.Lighten3)` for row coloring
 - Duration formatting: `$"{(int)ts.TotalHours}:{ts.Minutes:D2}"` from `TimeSpan`
+
+## 2026-04-08 16:05:26 - Attendance Display Name Fix
+
+**Task:** Fix AttendanceDto and SeatsController to use display Name instead of email
+
+**Changes Made:**
+- Updated AttendanceDto to include Name field alongside UserName
+- Modified CheckInController.GetAttendance to project User.Name in the query
+- Enhanced SeatsController.Assign to look up user from database and store display name
+
+**Files Modified:**
+- src/LanManager.Api/DTOs/CheckInDtos.cs
+- src/LanManager.Api/Controllers/CheckInController.cs  
+- src/LanManager.Api/Controllers/SeatsController.cs
+
+**Build & Test Results:**
+- Build: ✅ Success
+- Tests: ✅ All 62 tests passed
+
+**Branch:** fix/attendance-display-name
+**PR:** https://github.com/Arerir/LanManager_Squad/pull/121
+

--- a/.squad/agents/morgana/history.md
+++ b/.squad/agents/morgana/history.md
@@ -9,6 +9,50 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+## Seating Page UI Polish (2026-04-08)
+
+Fixed two visual issues in `SeatingPage.tsx`:
+
+**1. SVG Map Centering:**
+- Problem: SVG had `minWidth: '100%'` which forced it to stretch, preventing centering
+- Solution: Wrapped SVG in a `<div>` with `display: 'flex', justifyContent: 'center'`
+- SVG now has exact dimensions (`width={(maxCol + 1) * (SEAT_W + GAP)}`) with `display: 'block'`
+- Result: Map centers when smaller than panel, scrolls horizontally when wider
+
+**2. Attendee Card Redesign:**
+- Changed from horizontal pill layout to vertical card layout:
+  - `minHeight: 80`, `flexDirection: 'column'`, `justifyContent: 'space-between'`
+  - Header: seat status in uppercase with letterSpacing (green if assigned, red "UNASSIGNED" if not)
+  - Body: full attendee name at `fontSize: 1rem, fontWeight: 500`
+  - **Key change:** Unassigned cards now use `background: '#3a0000'` (dark red) instead of generic dark blue
+  - Grid minmax reduced to `160px` to fit taller cards
+- Visual impact: Unassigned attendees are immediately scannable via red cards
+
+**Branch/PR:** `fix/seating-ui-polish` → PR #119
+
+**Pattern:** When centering dynamic-width SVG: wrap in flex container, give SVG exact computed dimensions, parent container still handles overflow-x for scroll.
+
+## Issue #115 — Equipment Detail Modal with QR Code (2026-04-08)
+
+### What was done
+- Installed `qrcode.react` (no QR library existed in the project)
+- Created `frontend/src/components/EquipmentDetailModal.tsx`:
+  - `QRCodeSVG` at 220×220px on a white background pad
+  - All `EquipmentDto` fields in a read-only layout (name, type, qrCode, status badge, borrower info, notes)
+  - Edit button shown only to `Admin`/`Organizer` roles via `getUser().roles`
+  - Accessible: `role="dialog"`, `aria-modal`, focus trap, Escape key, click-backdrop close
+- Updated `EquipmentPage.tsx`:
+  - Row `onClick` opens `EquipmentDetailModal` with the clicked item
+  - Return button uses `e.stopPropagation()` to avoid row click conflict
+  - Edit navigates to `/equipment/:id/edit`
+- PR #117 opened
+
+### Key patterns
+- Role check: `getUser()` from `api/auth.ts` returns `LoginResponse` with `roles: string[]`; use `.some(r => ['Admin', 'Organizer'].includes(r))`
+- Modal close: expose both `onClose` (backdrop, Escape, close btn) and `onEdit` callbacks
+- `qrcode.react` exports `QRCodeSVG` (SVG) and `QRCodeCanvas` (canvas); SVG preferred for crisp rendering
+- Focus trap implemented manually via `keydown` listener; returns focus to previously focused element on unmount
+
 ## Event Context Persistence (2026-04-07)
 
 Implemented `EventContext` at `frontend/src/context/EventContext.tsx` to persist the selected event across sidebar navigation.
@@ -84,3 +128,47 @@ Implemented `EventContext` at `frontend/src/context/EventContext.tsx` to persist
 - Team: Merlin (backend service/PDF generator/endpoint), Radagast (tests), Circe (MAUI crew), Gandalf (merge orchestration)
 
 **Session Record:** Full PDF report sprint documented in `.squad/log/2026-04-08T12-20-05Z-pdf-sprint-complete.md` (20 todos completed, 6 PRs merged clean, zero conflicts)
+
+## Issue #114 — Seating View Dedicated Panel (2026-04-08)
+
+Promoted the seating map from a cramped flex sidebar column to its own full-width dedicated panel, with attendees in a separate card below.
+
+**What was done:**
+- `SeatingPage.tsx`: replaced two-column `flex` layout with stacked full-width panels
+- Seating SVG map now in its own card (`#12122a` bg, rounded border, horizontally scrollable)
+- Selected-seat callout moved inline at the bottom of the seating panel
+- Attendees section in a separate card below; rendered as a responsive grid (`auto-fill, minmax(200px, 1fr)`)
+- Attendee cards highlight blue when a seat is selected + empty, clarifying the click-to-assign flow
+- No functional changes — all role guards, assign/unassign, and grid setup preserved
+
+**Branch/PR:** `squad/114-seating-dedicated-panel` → PR #118
+
+**Layout note:** The attendees responsive grid scales nicely from narrow viewports (1 column) to wide desktop (5+ columns) without any media queries.
+## Seating Display Names (2026-04-08)
+
+Updated frontend to display user display names instead of email addresses on the seating page.
+
+**What was done:**
+- Added 
+ame: string field to AttendanceDto interface in rontend/src/api/attendance.ts
+- Updated SeatingPage.tsx attendee cards to show display name as primary text (1rem, bold) with email as secondary text below (0.72rem, muted)
+- Modified seat assignment call to pass .name instead of .userName to backend
+- Updated AttendancePage.tsx SignalR CheckedInBroadcast interface to include 
+ame field for real-time check-ins
+
+**UI Changes:**
+- Attendee cards now have three lines:
+  1. Header: "UNASSIGNED" or "Seat X1" (status)
+  2. Body: Display name (e.g., "John Doe") — NEW primary text
+  3. Sub-body: Email address (smaller, muted) — was previously the only identifier
+
+**Backend Coordination:**
+- This change depends on backend adding 
+ame field to AttendanceDto responses (API + SignalR broadcasts)
+- Backend also updating SeatsController.Assign to populate ssignedUserName from user's display name
+- Both PRs merge independently; frontend gracefully handles missing 
+ame field until backend is deployed
+
+**Branch/PR:** ix/seating-display-name-frontend → PR #120
+
+**Pattern:** When backend DTO changes in parallel, update TypeScript interfaces first, then usage sites, then build to catch any missed locations via compiler errors.

--- a/src/LanManager.Api.Tests/LanManager.Api.Tests.csproj
+++ b/src/LanManager.Api.Tests/LanManager.Api.Tests.csproj
@@ -8,6 +8,7 @@
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutputFormat>cobertura</CoverletOutputFormat>
     <CoverletOutput>Coverage/</CoverletOutput>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LanManager.Api/LanManager.Api.csproj
+++ b/src/LanManager.Api/LanManager.Api.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LanManager.AppHost/LanManager.AppHost.csproj
+++ b/src/LanManager.AppHost/LanManager.AppHost.csproj
@@ -15,6 +15,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>eefbbcad-174e-43bf-a41c-50f982bed0e4</UserSecretsId>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/LanManager.Data/LanManager.Data.csproj
+++ b/src/LanManager.Data/LanManager.Data.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LanManager.Maui.Crew/LanManager.Maui.Crew.csproj
+++ b/src/LanManager.Maui.Crew/LanManager.Maui.Crew.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>LanManager.Maui.Crew</RootNamespace>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>

--- a/src/LanManager.Maui.Crew/ViewModels/AttendanceViewModel.cs
+++ b/src/LanManager.Maui.Crew/ViewModels/AttendanceViewModel.cs
@@ -14,40 +14,40 @@ public partial class AttendanceViewModel : ObservableObject, IQueryAttributable
     private string _eventStatus = string.Empty;
 
     [ObservableProperty]
-    private ObservableCollection<AttendanceDto> _attendees = new();
+    public partial ObservableCollection<AttendanceDto> Attendees { get; set; } = new();
 
     [ObservableProperty]
-    private bool _isLoading;
+    public partial bool IsLoading { get; set; }
 
     [ObservableProperty]
-    private bool _isRefreshing;
+    public partial bool IsRefreshing { get; set; }
 
     [ObservableProperty]
-    private string _statusMessage = string.Empty;
+    public partial string StatusMessage { get; set; } = string.Empty;
 
     [ObservableProperty]
-    private bool _isEventClosed;
+    public partial bool IsEventClosed { get; set; }
 
     [ObservableProperty]
-    private bool _canDownloadReport;
+    public partial bool CanDownloadReport { get; set; }
 
     [ObservableProperty]
-    private bool _showReportPanel;
+    public partial bool ShowReportPanel { get; set; }
 
     [ObservableProperty]
-    private bool _isDownloading;
+    public partial bool IsDownloading { get; set; }
 
     [ObservableProperty]
-    private bool _includeRegistrations = true;
+    public partial bool IncludeRegistrations { get; set; } = true;
 
     [ObservableProperty]
-    private bool _includeCheckIns = true;
+    public partial bool IncludeCheckIns { get; set; } = true;
 
     [ObservableProperty]
-    private bool _includeEquipment = true;
+    public partial bool IncludeEquipment { get; set; } = true;
 
     [ObservableProperty]
-    private bool _includeTournaments = true;
+    public partial bool IncludeTournaments { get; set; } = true;
 
     public AttendanceViewModel(ApiService apiService, AuthService authService, AppStateService appState)
     {

--- a/src/LanManager.Maui.Crew/ViewModels/CheckInViewModel.cs
+++ b/src/LanManager.Maui.Crew/ViewModels/CheckInViewModel.cs
@@ -14,31 +14,31 @@ public partial class CheckInViewModel : ObservableObject, IQueryAttributable
     private Guid _eventId;
 
     [ObservableProperty]
-    private string _eventName = string.Empty;
+    public partial string EventName { get; set; } = string.Empty;
 
     [ObservableProperty]
-    private int _checkedInCount;
+    public partial int CheckedInCount { get; set; }
 
     [ObservableProperty]
-    private string _searchText = string.Empty;
+    public partial string SearchText { get; set; } = string.Empty;
 
     [ObservableProperty]
-    private ObservableCollection<UserDto> _filteredUsers = new();
+    public partial ObservableCollection<UserDto> FilteredUsers { get; set; } = new();
 
     [ObservableProperty]
-    private bool _isCheckOutMode;
+    public partial bool IsCheckOutMode { get; set; }
 
     [ObservableProperty]
-    private bool _isLoading;
+    public partial bool IsLoading { get; set; }
 
     [ObservableProperty]
-    private bool _canAccessDoorScan;
+    public partial bool CanAccessDoorScan { get; set; }
 
     [ObservableProperty]
-    private string _statusMessage = string.Empty;
+    public partial string StatusMessage { get; set; } = string.Empty;
 
     [ObservableProperty]
-    private Color _statusColor = Colors.Transparent;
+    public partial Color StatusColor { get; set; } = Colors.Transparent;
 
     public CheckInViewModel(ApiService apiService, AuthService authService, AppStateService appState)
     {

--- a/src/LanManager.Maui.Crew/ViewModels/DoorScanViewModel.cs
+++ b/src/LanManager.Maui.Crew/ViewModels/DoorScanViewModel.cs
@@ -13,14 +13,14 @@ public partial class DoorScanViewModel : ObservableObject, IQueryAttributable
     private DateTime _lastScanTime = DateTime.MinValue;
     private const int ScanCooldownMs = 1000;
 
-    [ObservableProperty] private string _eventName = string.Empty;
-    [ObservableProperty] private bool _isExitMode = true; // true=Exit, false=Entry
-    [ObservableProperty] private string _directionLabel = "EXIT";
-    [ObservableProperty] private Color _directionColor = Colors.Red;
-    [ObservableProperty] private string _statusMessage = string.Empty;
-    [ObservableProperty] private Color _statusColor = Colors.Transparent;
-    [ObservableProperty] private int _outsideCount;
-    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] public partial string EventName { get; set; } = string.Empty;
+    [ObservableProperty] public partial bool IsExitMode { get; set; } = true; // true=Exit, false=Entry
+    [ObservableProperty] public partial string DirectionLabel { get; set; } = "EXIT";
+    [ObservableProperty] public partial Color DirectionColor { get; set; } = Colors.Red;
+    [ObservableProperty] public partial string StatusMessage { get; set; } = string.Empty;
+    [ObservableProperty] public partial Color StatusColor { get; set; } = Colors.Transparent;
+    [ObservableProperty] public partial int OutsideCount { get; set; }
+    [ObservableProperty] public partial bool IsBusy { get; set; }
 
     public DoorScanViewModel(ApiService apiService, AuthService authService, AppStateService appState)
     {

--- a/src/LanManager.Maui.Crew/ViewModels/LoginViewModel.cs
+++ b/src/LanManager.Maui.Crew/ViewModels/LoginViewModel.cs
@@ -7,10 +7,10 @@ public partial class LoginViewModel : ObservableObject
 {
     private readonly AuthService _authService;
 
-    [ObservableProperty] private string _email = string.Empty;
-    [ObservableProperty] private string _password = string.Empty;
-    [ObservableProperty] private string _errorMessage = string.Empty;
-    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] public partial string Email { get; set; } = string.Empty;
+    [ObservableProperty] public partial string Password { get; set; } = string.Empty;
+    [ObservableProperty] public partial string ErrorMessage { get; set; } = string.Empty;
+    [ObservableProperty] public partial bool IsBusy { get; set; }
 
     public LoginViewModel(AuthService authService)
     {

--- a/src/LanManager.Maui.Crew/ViewModels/MainViewModel.cs
+++ b/src/LanManager.Maui.Crew/ViewModels/MainViewModel.cs
@@ -11,16 +11,16 @@ public partial class MainViewModel : ObservableObject
     private readonly AppStateService _appState;
 
     [ObservableProperty]
-    private ObservableCollection<EventDto> _events = new();
+    public partial ObservableCollection<EventDto> Events { get; set; } = new();
 
     [ObservableProperty]
-    private EventDto? _selectedEvent;
+    public partial EventDto? SelectedEvent { get; set; }
 
     [ObservableProperty]
-    private bool _isLoading;
+    public partial bool IsLoading { get; set; }
 
     [ObservableProperty]
-    private string _statusMessage = string.Empty;
+    public partial string StatusMessage { get; set; } = string.Empty;
 
     public MainViewModel(ApiService apiService, AppStateService appState)
     {

--- a/src/LanManager.Maui.Crew/Views/DoorScanPage.xaml.cs
+++ b/src/LanManager.Maui.Crew/Views/DoorScanPage.xaml.cs
@@ -13,7 +13,7 @@ public partial class DoorScanPage : ContentPage
         BindingContext = viewModel;
     }
 
-    private void OnBarcodesDetected(object sender, BarcodeDetectionEventArgs e)
+    private void OnBarcodesDetected(object? sender, BarcodeDetectionEventArgs e)
     {
         var first = e.Results.FirstOrDefault();
         if (first is null) return;

--- a/src/LanManager.Maui.Shared/LanManager.Maui.Shared.csproj
+++ b/src/LanManager.Maui.Shared/LanManager.Maui.Shared.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseMaui>true</UseMaui>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />

--- a/src/LanManager.Maui/LanManager.Maui.csproj
+++ b/src/LanManager.Maui/LanManager.Maui.csproj
@@ -13,6 +13,7 @@
 		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
 
 		<OutputType>Exe</OutputType>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<RootNamespace>LanManager.Maui</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>

--- a/src/LanManager.Maui/MauiProgram.cs
+++ b/src/LanManager.Maui/MauiProgram.cs
@@ -4,6 +4,7 @@ using LanManager.Maui.ViewModels;
 using LanManager.Maui.Views;
 using ZXing.Net.Maui.Controls;
 using AppStateService = LanManager.Maui.Services.AppStateService;
+using LanManager.Maui.Services;
 
 namespace LanManager.Maui;
 

--- a/src/LanManager.Maui/Services/SignalRService.cs
+++ b/src/LanManager.Maui/Services/SignalRService.cs
@@ -1,3 +1,5 @@
+using LanManager.Maui.Shared;
+using LanManager.Maui.Shared.Services;
 using Microsoft.AspNetCore.SignalR.Client;
 
 namespace LanManager.Maui.Services;

--- a/src/LanManager.Maui/ViewModels/AttendeeHubViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/AttendeeHubViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using LanManager.Maui.Shared.Services;
 using System.Collections.ObjectModel;
 using LanManager.Maui.Services;
+using AppStateService = LanManager.Maui.Services.AppStateService;
 
 namespace LanManager.Maui.ViewModels;
 
@@ -14,13 +15,13 @@ public partial class AttendeeHubViewModel : ObservableObject, IQueryAttributable
     private readonly SignalRService _signalRService;
     private Guid _eventId;
 
-    [ObservableProperty] private string _seatLabel = "No seat assigned";
-    [ObservableProperty] private string _seatDetail = string.Empty;
-    [ObservableProperty] private ObservableCollection<TournamentDto> _tournaments = new();
-    [ObservableProperty] private bool _isLoading;
-    [ObservableProperty] private string _statusMessage = string.Empty;
-    [ObservableProperty] private Color _statusColor = Colors.Gray;
-    [ObservableProperty] private string _tournamentStatus = string.Empty;
+    [ObservableProperty] public partial string SeatLabel { get; set; } = "No seat assigned";
+    [ObservableProperty] public partial string SeatDetail { get; set; } = string.Empty;
+    [ObservableProperty] public partial ObservableCollection<TournamentDto> Tournaments { get; set; } = new();
+    [ObservableProperty] public partial bool IsLoading { get; set; }
+    [ObservableProperty] public partial string StatusMessage { get; set; } = string.Empty;
+    [ObservableProperty] public partial Color StatusColor { get; set; } = Colors.Gray;
+    [ObservableProperty] public partial string TournamentStatus { get; set; } = string.Empty;
 
     public AttendeeHubViewModel(ApiService apiService, AppStateService appState, AuthService authService, SignalRService signalRService)
     {

--- a/src/LanManager.Maui/ViewModels/AttendeeQrViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/AttendeeQrViewModel.cs
@@ -11,10 +11,10 @@ public partial class AttendeeQrViewModel : ObservableObject, IQueryAttributable
     private readonly AppStateService _appState;
     private Guid _eventId;
 
-    [ObservableProperty] private ImageSource? _qrImageSource;
-    [ObservableProperty] private string _userName = string.Empty;
-    [ObservableProperty] private bool _isLoading;
-    [ObservableProperty] private string _statusMessage = string.Empty;
+    [ObservableProperty] public partial ImageSource? QrImageSource { get; set; }
+    [ObservableProperty] public partial string UserName { get; set; } = string.Empty;
+    [ObservableProperty] public partial bool IsLoading { get; set; }
+    [ObservableProperty] public partial string StatusMessage { get; set; } = string.Empty;
 
     public AttendeeQrViewModel(ApiService apiService, AuthService authService, AppStateService appState)
     {

--- a/src/LanManager.Maui/ViewModels/EquipmentScanViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/EquipmentScanViewModel.cs
@@ -11,10 +11,10 @@ public partial class EquipmentScanViewModel : ObservableObject
     private DateTime _lastScanTime = DateTime.MinValue;
     private const int ScanCooldownMs = 2000;
 
-    [ObservableProperty] private ObservableCollection<EquipmentLoanDto> _myLoans = new();
-    [ObservableProperty] private string _statusMessage = string.Empty;
-    [ObservableProperty] private Color _statusColor = Colors.Transparent;
-    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] public partial ObservableCollection<EquipmentLoanDto> MyLoans { get; set; } = new();
+    [ObservableProperty] public partial string StatusMessage { get; set; } = string.Empty;
+    [ObservableProperty] public partial Color StatusColor { get; set; } = Colors.Transparent;
+    [ObservableProperty] public partial bool IsBusy { get; set; }
 
     public EquipmentScanViewModel(ApiService apiService)
     {

--- a/src/LanManager.Maui/ViewModels/LoginViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/LoginViewModel.cs
@@ -8,10 +8,10 @@ public partial class LoginViewModel : ObservableObject
 {
     private readonly AuthService _authService;
 
-    [ObservableProperty] private string _email = string.Empty;
-    [ObservableProperty] private string _password = string.Empty;
-    [ObservableProperty] private string _errorMessage = string.Empty;
-    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] public partial string Email { get; set; } = string.Empty;
+    [ObservableProperty] public partial string Password { get; set; } = string.Empty;
+    [ObservableProperty] public partial string ErrorMessage { get; set; } = string.Empty;
+    [ObservableProperty] public partial bool IsBusy { get; set; }
 
     public LoginViewModel(AuthService authService)
     {

--- a/src/LanManager.Maui/ViewModels/MainViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/MainViewModel.cs
@@ -2,7 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LanManager.Maui.Shared.Services;
 using System.Collections.ObjectModel;
-using LanManager.Maui.Services;
+using AppStateService = LanManager.Maui.Services.AppStateService;
 
 namespace LanManager.Maui.ViewModels;
 
@@ -13,16 +13,16 @@ public partial class MainViewModel : ObservableObject
     private readonly AppStateService _appState;
 
     [ObservableProperty]
-    private ObservableCollection<EventDto> _events = new();
+    public partial ObservableCollection<EventDto> Events { get; set; } = new();
 
     [ObservableProperty]
-    private EventDto? _selectedEvent;
+    public partial EventDto? SelectedEvent { get; set; }
 
     [ObservableProperty]
-    private bool _isLoading;
+    public partial bool IsLoading { get; set; }
 
     [ObservableProperty]
-    private string _statusMessage = string.Empty;
+    public partial string StatusMessage { get; set; } = string.Empty;
 
     public MainViewModel(ApiService apiService, AuthService authService, AppStateService appState)
     {

--- a/src/LanManager.Maui/Views/AttendeeHubPage.xaml
+++ b/src/LanManager.Maui/Views/AttendeeHubPage.xaml
@@ -11,13 +11,13 @@
     <StackLayout Padding="20" Spacing="20">
 
       <!-- Seat card -->
-      <Frame BackgroundColor="#1a1a2e" CornerRadius="10" Padding="16">
+      <Border BackgroundColor="#1a1a2e" StrokeShape="RoundRectangle 10" Padding="16">
         <StackLayout>
           <Label Text="My Seat" TextColor="#aaa" FontSize="14"/>
           <Label Text="{Binding SeatLabel}" TextColor="White" FontSize="32" FontAttributes="Bold"/>
           <Label Text="{Binding SeatDetail}" TextColor="#aaa" FontSize="14"/>
         </StackLayout>
-      </Frame>
+      </Border>
 
       <!-- My QR code button -->
       <Button Text="📷 Show My QR Code" Command="{Binding GoToQrPageCommand}"
@@ -34,7 +34,7 @@
       <CollectionView ItemsSource="{Binding Tournaments}">
         <CollectionView.ItemTemplate>
           <DataTemplate x:DataType="services:TournamentDto">
-            <Frame BackgroundColor="#1a1a2e" CornerRadius="8" Padding="12" Margin="0,0,0,8">
+            <Border BackgroundColor="#1a1a2e" StrokeShape="RoundRectangle 8" Padding="12" Margin="0,0,0,8">
               <Grid ColumnDefinitions="*,Auto">
                 <StackLayout Grid.Column="0">
                   <Label Text="{Binding Name}" TextColor="White" FontSize="16" FontAttributes="Bold"/>
@@ -47,7 +47,7 @@
                         BackgroundColor="#27ae60" TextColor="White"
                         CornerRadius="6" Padding="10,6"/>
               </Grid>
-            </Frame>
+            </Border>
           </DataTemplate>
         </CollectionView.ItemTemplate>
       </CollectionView>

--- a/src/LanManager.Maui/Views/AttendeeQrPage.xaml
+++ b/src/LanManager.Maui/Views/AttendeeQrPage.xaml
@@ -9,11 +9,11 @@
   <Grid RowDefinitions="Auto,*,Auto" Padding="20">
     <Label Grid.Row="0" Text="{Binding UserName}" TextColor="White" FontSize="22"
            FontAttributes="Bold" HorizontalOptions="Center" Margin="0,0,0,20"/>
-    <Frame Grid.Row="1" BackgroundColor="White" CornerRadius="12" Padding="16"
+    <Border Grid.Row="1" BackgroundColor="White" StrokeShape="RoundRectangle 12" Padding="16"
            HorizontalOptions="Center" VerticalOptions="Center"
            IsVisible="{Binding QrImageSource, Converter={StaticResource IsNotNullConverter}}">
       <Image Source="{Binding QrImageSource}" WidthRequest="260" HeightRequest="260"/>
-    </Frame>
+    </Border>
     <ActivityIndicator Grid.Row="1" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                        Color="White" VerticalOptions="Center"/>
     <Label Grid.Row="2" Text="{Binding StatusMessage}" TextColor="#aaa"

--- a/src/LanManager.Maui/Views/EquipmentScanPage.xaml
+++ b/src/LanManager.Maui/Views/EquipmentScanPage.xaml
@@ -20,7 +20,7 @@
     <zxing:CameraBarcodeReaderView Grid.Row="1" x:Name="cameraView" BarcodesDetected="OnBarcodesDetected"/>
 
     <!-- Active loans list -->
-    <Frame Grid.Row="2" BackgroundColor="#1a1a2e" Padding="12" Margin="0" CornerRadius="0">
+    <Border Grid.Row="2" BackgroundColor="#1a1a2e" Padding="12" Margin="0" StrokeShape="RoundRectangle 0">
       <StackLayout>
         <Label Text="Currently borrowed:" TextColor="#aaa" FontSize="13"/>
         <CollectionView ItemsSource="{Binding MyLoans}">
@@ -40,7 +40,7 @@
         <Label Text="None" TextColor="#666" FontSize="13"
                IsVisible="{Binding MyLoans.Count, Converter={StaticResource IsZeroConverter}}"/>
       </StackLayout>
-    </Frame>
+    </Border>
 
     <!-- Status Banner -->
     <Border Grid.Row="3" BackgroundColor="{Binding StatusColor}"

--- a/src/LanManager.Maui/Views/EquipmentScanPage.xaml.cs
+++ b/src/LanManager.Maui/Views/EquipmentScanPage.xaml.cs
@@ -19,7 +19,7 @@ public partial class EquipmentScanPage : ContentPage
         await ViewModel.InitAsync();
     }
 
-    private void OnBarcodesDetected(object sender, BarcodeDetectionEventArgs e)
+    private void OnBarcodesDetected(object? sender, BarcodeDetectionEventArgs e)
     {
         var first = e.Results.FirstOrDefault();
         if (first is null) return;

--- a/src/LanManager.ServiceDefaults/LanManager.ServiceDefaults.csproj
+++ b/src/LanManager.ServiceDefaults/LanManager.ServiceDefaults.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Fixes all existing compiler warnings and the one build error, then enables TreatWarningsAsErrors across all .NET projects.

### Changes
- Fix CS0103: Add missing using LanManager.Maui.Shared in SignalRService.cs
- Fix CS0618: Replace obsolete Frame with Border in 3 XAML files (AttendeeQrPage, EquipmentScanPage, AttendeeHubPage)
- Fix CS8622: Change object sender to object? sender in OnBarcodesDetected handlers (EquipmentScanPage, DoorScanPage)
- Fix MVVMTK0045: Convert all [ObservableProperty] private fields to partial properties in 10 ViewModels across LanManager.Maui and LanManager.Maui.Crew
- Enable TreatWarningsAsErrors: Added to all 8 .csproj files

### Verification
- LanManager.Maui: Build succeeded - 0 warnings, 0 errors
- LanManager.Maui.Crew: Build succeeded - 0 warnings, 0 errors
- LanManager.Api: Build succeeded - 0 warnings, 0 errors
- LanManager.Api.Tests: 69 passed, 1 skipped (intentional), 0 failed