### PR TITLE
fix: Equipment borrow eventId and attendee QR availability

### DIFF
--- a/src/LanManager.Api/Controllers/DoorPassController.cs
+++ b/src/LanManager.Api/Controllers/DoorPassController.cs
@@ -33,9 +33,9 @@ public class DoorPassController(
                 return Forbid();
         }
 
-        var isRegistered = await db.Registrations
-            .AnyAsync(r => r.EventId == eventId && r.UserId == userId);
-        if (!isRegistered)
+        var hasAccess = await db.Registrations.AnyAsync(r => r.EventId == eventId && r.UserId == userId)
+            || await db.CheckInRecords.AnyAsync(c => c.EventId == eventId && c.UserId == userId);
+        if (!hasAccess)
             return NotFound(new { message = "User is not registered for this event." });
 
         var qrGenerator = new QRCodeGenerator();

--- a/src/LanManager.Maui.Shared/Services/ApiService.cs
+++ b/src/LanManager.Maui.Shared/Services/ApiService.cs
@@ -194,9 +194,9 @@ public class ApiService
         }
     }
 
-    public async Task<EquipmentLoanDto?> BorrowEquipmentAsync(string qrCode)
+    public async Task<EquipmentLoanDto?> BorrowEquipmentAsync(string qrCode, Guid eventId)
     {
-        var response = await _httpClient.PostAsync($"/api/equipment/borrow/{Uri.EscapeDataString(qrCode)}", null);
+        var response = await _httpClient.PostAsync($"/api/equipment/borrow/{Uri.EscapeDataString(qrCode)}?eventId={eventId}", null);
         if (response.IsSuccessStatusCode)
             return await response.Content.ReadFromJsonAsync<EquipmentLoanDto>(_jsonOptions);
         var error = await response.Content.ReadAsStringAsync();

--- a/src/LanManager.Maui/ViewModels/AttendeeHubViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/AttendeeHubViewModel.cs
@@ -138,7 +138,7 @@ public partial class AttendeeHubViewModel : ObservableObject, IQueryAttributable
 
     [RelayCommand]
     private async Task GoToEquipmentScanAsync()
-        => await Shell.Current.GoToAsync("EquipmentScanPage");
+        => await Shell.Current.GoToAsync($"EquipmentScanPage?eventId={_eventId}");
 
     [RelayCommand]
     private async Task GoToDoorScannerAsync()

--- a/src/LanManager.Maui/ViewModels/EquipmentScanViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/EquipmentScanViewModel.cs
@@ -5,11 +5,18 @@ using System.Collections.ObjectModel;
 
 namespace LanManager.Maui.ViewModels;
 
-public partial class EquipmentScanViewModel : ObservableObject
+public partial class EquipmentScanViewModel : ObservableObject, IQueryAttributable
 {
     private readonly ApiService _apiService;
+    private Guid _eventId;
     private DateTime _lastScanTime = DateTime.MinValue;
     private const int ScanCooldownMs = 2000;
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("eventId", out var id) && Guid.TryParse(id?.ToString(), out var guid))
+            _eventId = guid;
+    }
 
     [ObservableProperty] public partial ObservableCollection<EquipmentLoanDto> MyLoans { get; set; } = new();
     [ObservableProperty] public partial string StatusMessage { get; set; } = string.Empty;
@@ -37,7 +44,7 @@ public partial class EquipmentScanViewModel : ObservableObject
 
         try
         {
-            var loan = await _apiService.BorrowEquipmentAsync(barcodeValue);
+            var loan = await _apiService.BorrowEquipmentAsync(barcodeValue, _eventId);
             ShowSuccess($"✓ Borrowed: {loan?.EquipmentName}");
             await InitAsync();
         }


### PR DESCRIPTION
## Fixes

### Bug 1: Equipment borrow sends empty event ID
- \AttendeeHubViewModel\ now passes \ventId\ when navigating to EquipmentScanPage
- \EquipmentScanViewModel\ implements \IQueryAttributable\ to receive eventId
- \BorrowEquipmentAsync\ now includes \?eventId=\ in the API request URL

### Bug 2: Attendee QR code not available
- Fixed QR availability check to accept checked-in attendees, not just formally registered users