### PR TITLE
feat: Camera flip button on scanner pages (Crew + Attendee)

### DIFF
--- a/.squad/agents/gandalf/history.md
+++ b/.squad/agents/gandalf/history.md
@@ -218,3 +218,29 @@ Labels used: squad, enhancement, squad:tank, squad:apoc, squad:trinity, squad:sw
 - QR availability fix: Logical OR correctly expands access from formal registrations to any checked-in attendee
 - No regressions — both fixes are minimal and focused on their specific issues
 - Query param implementation is idiomatic MAUI navigation pattern
+
+### 2026-04-09: PRs #125 & #126 Merged — DoorLog SignalR + Door Scan Sprint
+**Merged:** PR #125 (Morgana — DoorLog SignalR), PR #126 (Merlin — Door scan auto-direction, status, QR colors, Crew login gate)
+
+**CI Status (both):** ✅ 4/4 checks passing (API Tests, Build API, Build Frontend, GitGuardian)
+
+**PR #125 — feat/doorlog-signalr-frontend:**
+- `DoorScanBroadcast` TypeScript interface fully typed (eventId, userId, userName, direction, scannedAt)
+- SignalR connection cleanup on unmount confirmed: `return () => { connection.stop(); }` — no leaks
+- Event scoping guard (`if (payload.eventId !== eventId) return`) prevents cross-event SignalR bleed
+- Entry=green (`#27ae60`), Exit=red (`#c0392b`) pill badges — semantically correct
+- Hub status badge (Live/Reconnecting.../Disconnected) with `withAutomaticReconnect()` + all three reconnect handlers
+- Merge: `gh pr merge 125 --squash --delete-branch --admin`
+
+**PR #126 — feat/door-scan-status-sprint:**
+- **Auto-flip direction**: Queries user's latest door pass before saving; if last was Exit, forces Entry regardless of what crew app sends. Idempotency at API level — prevents double-exits.
+- **Status endpoint**: `GET /api/events/{eventId}/attendees/{userId}/door-status` returns `{ status: "Entry"|"Exit"|"Unregistered" }`. Auth: staff can query any; attendees self-only. Matches GetQrCode pattern.
+- **QR page colors**: `BackgroundColor="{Binding PageBackground}"` binding; `ApplyStatus()` sets dark green/red/purple; `StatusMessage` TextColor changed to White for readability.
+- **Crew login gate**: `LogoutAsync()` called before setting `ErrorMessage` — user is cleanly logged out first, then shown "Access denied" message. `IsBusy = false` + `return` prevents navigation.
+- Merge: `gh pr merge 126 --squash --delete-branch --admin`
+
+**Review Notes:**
+- Both PRs are well-scoped, zero regressions detected
+- `TreatWarningsAsErrors` enforced since PR #122 — both compile clean
+- Direction auto-flip is a strong API-level guard; crew UI direction selection still works for first scan and Exit initiation
+- Crew login gate is correctly a UX guard (not sole security boundary); API auth remains authoritative

--- a/src/LanManager.Maui.Crew/ViewModels/DoorScanViewModel.cs
+++ b/src/LanManager.Maui.Crew/ViewModels/DoorScanViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LanManager.Maui.Shared.Services;
+using ZXing.Net.Maui;
 
 namespace LanManager.Maui.Crew.ViewModels;
 
@@ -15,6 +16,7 @@ public partial class DoorScanViewModel : ObservableObject, IQueryAttributable
 
     [ObservableProperty] public partial string EventName { get; set; } = string.Empty;
     [ObservableProperty] public partial bool IsExitMode { get; set; } = true; // true=Exit, false=Entry
+    [ObservableProperty] public partial CameraLocation CameraFacing { get; set; } = CameraLocation.Rear;
     [ObservableProperty] public partial string DirectionLabel { get; set; } = "EXIT";
     [ObservableProperty] public partial Color DirectionColor { get; set; } = Colors.Red;
     [ObservableProperty] public partial string StatusMessage { get; set; } = string.Empty;
@@ -47,6 +49,12 @@ public partial class DoorScanViewModel : ObservableObject, IQueryAttributable
     private async Task InitAsync()
     {
         await RefreshOutsideCountAsync();
+    }
+
+    [RelayCommand]
+    private void ToggleCamera()
+    {
+        CameraFacing = CameraFacing == CameraLocation.Rear ? CameraLocation.Front : CameraLocation.Rear;
     }
 
     [RelayCommand]

--- a/src/LanManager.Maui.Crew/Views/DoorScanPage.xaml
+++ b/src/LanManager.Maui.Crew/Views/DoorScanPage.xaml
@@ -26,10 +26,22 @@
         <Label Grid.Row="2" Text="{Binding OutsideCount, StringFormat='{0} outside'}"
                HorizontalOptions="Center" Margin="8" FontSize="14" TextColor="Gray"/>
 
-        <!-- Camera -->
-        <zxing:CameraBarcodeReaderView Grid.Row="3"
-                          x:Name="cameraView"
-                          BarcodesDetected="OnBarcodesDetected"/>
+        <!-- Camera with flip button overlay -->
+        <Grid Grid.Row="3">
+            <zxing:CameraBarcodeReaderView x:Name="cameraView"
+                              CameraLocation="{Binding CameraFacing}"
+                              BarcodesDetected="OnBarcodesDetected"/>
+            <Button Text="⇄ Flip Camera"
+                    Command="{Binding ToggleCameraCommand}"
+                    HorizontalOptions="End"
+                    VerticalOptions="Start"
+                    Margin="8"
+                    BackgroundColor="#AA000000"
+                    TextColor="White"
+                    FontSize="13"
+                    CornerRadius="20"
+                    Padding="12,6"/>
+        </Grid>
 
         <!-- Status Banner -->
         <Border Grid.Row="4" BackgroundColor="{Binding StatusColor}"

--- a/src/LanManager.Maui/ViewModels/EquipmentScanViewModel.cs
+++ b/src/LanManager.Maui/ViewModels/EquipmentScanViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LanManager.Maui.Shared.Services;
 using System.Collections.ObjectModel;
+using ZXing.Net.Maui;
 
 namespace LanManager.Maui.ViewModels;
 
@@ -18,6 +19,7 @@ public partial class EquipmentScanViewModel : ObservableObject, IQueryAttributab
             _eventId = guid;
     }
 
+    [ObservableProperty] public partial CameraLocation CameraFacing { get; set; } = CameraLocation.Rear;
     [ObservableProperty] public partial ObservableCollection<EquipmentLoanDto> MyLoans { get; set; } = new();
     [ObservableProperty] public partial string StatusMessage { get; set; } = string.Empty;
     [ObservableProperty] public partial Color StatusColor { get; set; } = Colors.Transparent;
@@ -58,6 +60,12 @@ public partial class EquipmentScanViewModel : ObservableObject, IQueryAttributab
         {
             IsBusy = false;
         }
+    }
+
+    [RelayCommand]
+    private void ToggleCamera()
+    {
+        CameraFacing = CameraFacing == CameraLocation.Rear ? CameraLocation.Front : CameraLocation.Rear;
     }
 
     [RelayCommand]

--- a/src/LanManager.Maui/Views/EquipmentScanPage.xaml
+++ b/src/LanManager.Maui/Views/EquipmentScanPage.xaml
@@ -16,8 +16,22 @@
               BackgroundColor="Transparent" TextColor="White"/>
     </Grid>
 
-    <!-- Camera -->
-    <zxing:CameraBarcodeReaderView Grid.Row="1" x:Name="cameraView" BarcodesDetected="OnBarcodesDetected"/>
+    <!-- Camera with flip button overlay -->
+    <Grid Grid.Row="1">
+      <zxing:CameraBarcodeReaderView x:Name="cameraView"
+                        CameraLocation="{Binding CameraFacing}"
+                        BarcodesDetected="OnBarcodesDetected"/>
+      <Button Text="⇄ Flip Camera"
+              Command="{Binding ToggleCameraCommand}"
+              HorizontalOptions="End"
+              VerticalOptions="Start"
+              Margin="8"
+              BackgroundColor="#AA000000"
+              TextColor="White"
+              FontSize="13"
+              CornerRadius="20"
+              Padding="12,6"/>
+    </Grid>
 
     <!-- Active loans list -->
     <Border Grid.Row="2" BackgroundColor="#1a1a2e" Padding="12" Margin="0" StrokeShape="RoundRectangle 0">


### PR DESCRIPTION
## What
Adds a flip-camera button overlaid on the scanner view in both apps.

## Where
- **Crew app** — DoorScanPage: overlay button top-right of the camera view
- **Attendee app** — EquipmentScanPage: overlay button top-right of the camera view

## How
- \CameraFacing\ property (CameraLocation enum) on both ViewModels
- \ToggleCameraCommand\ toggles Rear ↔ Front
- XAML binds \CameraLocation\ on the \CameraBarcodeReaderView\
- Button styled as semi-transparent dark pill, top-right corner, non-intrusive